### PR TITLE
Improve backtester UI and results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# backtester
+# Backtester
+
+This project provides a simple Java Spring Boot backend and a basic HTML frontend for running trading strategy backtests using data from the Zerodha KITE API. Price data is cached in Redis to avoid redundant requests. A small in-memory history is kept for previous runs.
+
+## Backend
+
+The backend is located in the `backend` directory. It exposes a REST endpoint `/api/backtest` that accepts strategy name, symbol, candle period (e.g. `1d`, `1m`, `5m`, `30m`, `1w`), date range and initial capital. Supported strategies now cover a wide selection including:
+
+* `RSI`, `MACD`, `BollingerBands`, `Supertrend`
+* `RSI_SMA`, `MACD_CROSS`, `Bollinger_Reversal`, `Golden_Cross`
+* `Breakout`, `ADX_DI`, `VWAP_Pullback`, `RSI_EMA`
+* `MACD_Hist`, `Opening_Range`, `Scalp_Supertrend`, `MA_Ribbon`, `Mean_VWAP`
+
+All algorithms operate on any candle period provided.
+
+Price quotes are fetched from Zerodha KITE in `QuoteService` and cached in Redis and an in-memory map. Each cached entry stores the full candle (time, open, high, low, close, volume) keyed by symbol and candle period. Set `KITE_API_KEY` and `KITE_ACCESS_TOKEN` environment variables before running. History of executed backtests can be retrieved from `/api/backtest/history`.
+
+## Frontend
+
+Open `frontend/index.html` in a browser. The page now includes styled form controls
+with dropdowns for candle periods and strategies, date pickers for the time
+range and a results panel.  After a run it plots the closing prices and marks
+trade entry/exit points while showing initial capital, final capital, profit
+percentage and drawdown.
+The chart is rendered with [Chart.js](https://www.chartjs.org/) and basic styling
+is provided by Bootstrap.
+
+## Building
+
+This is a standard Maven project:
+
+```bash
+cd backend
+mvn package
+```
+
+Running the Spring Boot application will serve the API on `localhost:8080`.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.backtester</groupId>
+    <artifactId>backtester</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <properties>
+        <java.version>11</java.version>
+        <spring.boot.version>2.7.3</spring.boot.version>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>4.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/com/backtester/BacktesterApplication.java
+++ b/backend/src/main/java/com/backtester/BacktesterApplication.java
@@ -1,0 +1,11 @@
+package com.backtester;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BacktesterApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BacktesterApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/backtester/controller/BacktestController.java
+++ b/backend/src/main/java/com/backtester/controller/BacktestController.java
@@ -1,0 +1,51 @@
+package com.backtester.controller;
+
+import com.backtester.model.Candle;
+import com.backtester.service.HistoryService;
+import com.backtester.service.QuoteService;
+import com.backtester.service.StrategyFactory;
+import com.backtester.strategy.BacktestResult;
+import com.backtester.strategy.Strategy;
+import java.util.stream.Collectors;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/backtest")
+public class BacktestController {
+    private final QuoteService quoteService;
+    private final StrategyFactory strategyFactory;
+    private final HistoryService historyService;
+
+    public BacktestController(QuoteService quoteService, StrategyFactory strategyFactory, HistoryService historyService) {
+        this.quoteService = quoteService;
+        this.strategyFactory = strategyFactory;
+        this.historyService = historyService;
+    }
+
+    @GetMapping
+    public BacktestResult run(@RequestParam String strategy,
+                              @RequestParam String symbol,
+                              @RequestParam String period,
+                              @RequestParam String from,
+                              @RequestParam String to,
+                              @RequestParam double capital) {
+        Strategy strat = strategyFactory.getStrategy(strategy);
+        if (strat == null) {
+            throw new IllegalArgumentException("Unknown strategy: " + strategy);
+        }
+        List<Candle> candles = quoteService.getCandles(symbol, period, from, to);
+        List<Double> prices = candles.stream().map(Candle::getClose).collect(Collectors.toList());
+        BacktestResult result = strat.run(prices, capital);
+        result.setCandles(candles);
+        result.setInitialCapital(capital);
+        historyService.add(strategy + " " + symbol + " => " + result.getFinalCapital());
+        return result;
+    }
+
+    @GetMapping("/history")
+    public List<String> history() {
+        return historyService.getHistory();
+    }
+}

--- a/backend/src/main/java/com/backtester/model/Candle.java
+++ b/backend/src/main/java/com/backtester/model/Candle.java
@@ -1,0 +1,26 @@
+package com.backtester.model;
+
+public class Candle {
+    private final String time;
+    private final double open;
+    private final double high;
+    private final double low;
+    private final double close;
+    private final double volume;
+
+    public Candle(String time, double open, double high, double low, double close, double volume) {
+        this.time = time;
+        this.open = open;
+        this.high = high;
+        this.low = low;
+        this.close = close;
+        this.volume = volume;
+    }
+
+    public String getTime() { return time; }
+    public double getOpen() { return open; }
+    public double getHigh() { return high; }
+    public double getLow() { return low; }
+    public double getClose() { return close; }
+    public double getVolume() { return volume; }
+}

--- a/backend/src/main/java/com/backtester/service/HistoryService.java
+++ b/backend/src/main/java/com/backtester/service/HistoryService.java
@@ -1,0 +1,20 @@
+package com.backtester.service;
+
+import com.backtester.strategy.BacktestResult;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedList;
+import java.util.List;
+
+@Service
+public class HistoryService {
+    private final List<String> history = new LinkedList<>();
+
+    public void add(String entry) {
+        history.add(0, entry);
+    }
+
+    public List<String> getHistory() {
+        return history;
+    }
+}

--- a/backend/src/main/java/com/backtester/service/QuoteService.java
+++ b/backend/src/main/java/com/backtester/service/QuoteService.java
@@ -1,0 +1,109 @@
+package com.backtester.service;
+
+import com.backtester.model.Candle;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import redis.clients.jedis.Jedis;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class QuoteService {
+    private final Jedis jedis = new Jedis("localhost");
+    private final Map<String, List<Candle>> memoryCache = new ConcurrentHashMap<>();
+
+    public List<Double> getPrices(String symbol, String period, String from, String to) {
+        List<Candle> candles = getCandles(symbol, period, from, to);
+        List<Double> prices = new ArrayList<>();
+        for (Candle c : candles) prices.add(c.getClose());
+        return prices;
+    }
+
+    public List<Candle> getCandles(String symbol, String period, String from, String to) {
+        String key = symbol + ":" + period + ":" + from + ":" + to;
+        if (memoryCache.containsKey(key)) {
+            return memoryCache.get(key);
+        } else if (jedis.exists(key)) {
+            List<Candle> cached = parseCandles(jedis.lrange(key, 0, -1));
+            memoryCache.put(key, cached);
+            return cached;
+        }
+
+        List<Candle> candles = fetchFromKite(symbol, period, from, to);
+        if (candles != null) {
+            for (Candle c : candles) {
+                String line = String.join(",",
+                        c.getTime(),
+                        Double.toString(c.getOpen()),
+                        Double.toString(c.getHigh()),
+                        Double.toString(c.getLow()),
+                        Double.toString(c.getClose()),
+                        Double.toString(c.getVolume()));
+                jedis.rpush(key, line);
+            }
+            memoryCache.put(key, candles);
+        }
+        return candles;
+    }
+
+    private List<Candle> parseCandles(List<String> values) {
+        List<Candle> list = new ArrayList<>();
+        for (String v : values) {
+            String[] parts = v.split(",");
+            if (parts.length < 6) continue;
+            Candle c = new Candle(parts[0],
+                    Double.parseDouble(parts[1]),
+                    Double.parseDouble(parts[2]),
+                    Double.parseDouble(parts[3]),
+                    Double.parseDouble(parts[4]),
+                    Double.parseDouble(parts[5]));
+            list.add(c);
+        }
+        return list;
+    }
+
+    private List<Candle> fetchFromKite(String symbol, String period, String from, String to) {
+        String apiKey = System.getenv("KITE_API_KEY");
+        String accessToken = System.getenv("KITE_ACCESS_TOKEN");
+        String url = String.format(
+                "https://api.kite.trade/instruments/historical/%s/%s?from=%s&to=%s&interval=%s&api_key=%s&access_token=%s",
+                symbol, period, from, to, period, apiKey, accessToken);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("X-Kite-Version", "3")
+                .build();
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                return new ArrayList<>();
+            }
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(response.body());
+            List<Candle> list = new ArrayList<>();
+            for (JsonNode c : root.path("data").path("candles")) {
+                Candle candle = new Candle(
+                        c.get(0).asText(),
+                        c.get(1).asDouble(),
+                        c.get(2).asDouble(),
+                        c.get(3).asDouble(),
+                        c.get(4).asDouble(),
+                        c.get(5).asDouble());
+                list.add(candle);
+            }
+            return list;
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+            return new ArrayList<>();
+        }
+    }
+}

--- a/backend/src/main/java/com/backtester/service/StrategyFactory.java
+++ b/backend/src/main/java/com/backtester/service/StrategyFactory.java
@@ -1,0 +1,40 @@
+package com.backtester.service;
+
+import com.backtester.strategy.*;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class StrategyFactory {
+    private final Map<String, Strategy> strategies = new HashMap<>();
+
+    public StrategyFactory() {
+        register(new RSIStrategy());
+        register(new MACDStrategy());
+        register(new BollingerStrategy());
+        register(new SupertrendStrategy());
+        register(new RSISMACrossoverStrategy());
+        register(new MACDCrossStrategy());
+        register(new BollingerReversalStrategy());
+        register(new GoldenCrossStrategy());
+        register(new BreakoutStrategy());
+        register(new ADXDIStrategy());
+        register(new VWAPPullbackStrategy());
+        register(new RSIEMABounceStrategy());
+        register(new MACDHistogramStrategy());
+        register(new OpeningRangeBreakoutStrategy());
+        register(new ScalpingSupertrendStrategy());
+        register(new MovingAverageRibbonStrategy());
+        register(new MeanReversionVWAPStrategy());
+    }
+
+    private void register(Strategy s) {
+        strategies.put(s.getName().toLowerCase(), s);
+    }
+
+    public Strategy getStrategy(String name) {
+        return strategies.get(name.toLowerCase());
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/ADXDIStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/ADXDIStrategy.java
@@ -1,0 +1,42 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.*;
+
+public class ADXDIStrategy implements Strategy {
+    @Override
+    public String getName() { return "ADX_DI"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int period = 14;
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+
+        for (int i = period; i < prices.size(); i++) {
+            double adxVal = adx(prices, i, period);
+            double up = highest(prices, i, 1) - prices.get(i-1);
+            double down = prices.get(i-1) - lowest(prices, i, 1);
+            boolean diPlus = up > down;
+            double price = prices.get(i);
+
+            if (adxVal > 25 && diPlus && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (adxVal > 25 && !diPlus && position == 1) {
+                position = 0;
+                cash += price;
+            }
+
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity)/peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size()-1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/BacktestResult.java
+++ b/backend/src/main/java/com/backtester/strategy/BacktestResult.java
@@ -1,0 +1,65 @@
+package com.backtester.strategy;
+
+import com.backtester.model.Candle;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BacktestResult {
+    private double initialCapital;
+    private double finalCapital;
+    private double maxDrawdown;
+    private List<Candle> candles = new ArrayList<>();
+    private List<Trade> trades = new ArrayList<>();
+    private List<Double> equityCurve = new ArrayList<>();
+
+    public BacktestResult(double finalCapital, double maxDrawdown) {
+        this.finalCapital = finalCapital;
+        this.maxDrawdown = maxDrawdown;
+    }
+
+    public double getInitialCapital() {
+        return initialCapital;
+    }
+
+    public void setInitialCapital(double initialCapital) {
+        this.initialCapital = initialCapital;
+    }
+
+    public double getFinalCapital() {
+        return finalCapital;
+    }
+
+    public double getProfitPercent() {
+        if (initialCapital == 0) return 0;
+        return (finalCapital - initialCapital) * 100.0 / initialCapital;
+    }
+
+    public double getMaxDrawdown() {
+        return maxDrawdown;
+    }
+
+    public List<Candle> getCandles() {
+        return candles;
+    }
+
+    public void setCandles(List<Candle> candles) {
+        this.candles = candles;
+    }
+
+    public List<Trade> getTrades() {
+        return trades;
+    }
+
+    public void setTrades(List<Trade> trades) {
+        this.trades = trades;
+    }
+
+    public List<Double> getEquityCurve() {
+        return equityCurve;
+    }
+
+    public void setEquityCurve(List<Double> equityCurve) {
+        this.equityCurve = equityCurve;
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/BollingerReversalStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/BollingerReversalStrategy.java
@@ -1,0 +1,47 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.sma;
+
+public class BollingerReversalStrategy implements Strategy {
+    @Override
+    public String getName() { return "Bollinger_Reversal"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int period = 20;
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+
+        for (int i = period; i < prices.size(); i++) {
+            double ma = sma(prices, i, period);
+            double sd = 0.0;
+            for (int j = i - period + 1; j <= i; j++) {
+                double diff = prices.get(j) - ma;
+                sd += diff * diff;
+            }
+            sd = Math.sqrt(sd / period);
+            double upper = ma + 2 * sd;
+            double lower = ma - 2 * sd;
+            double price = prices.get(i);
+
+            if (price < lower && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (price > upper && position == 1) {
+                position = 0;
+                cash += price;
+            }
+
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity) / peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size() - 1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/BollingerStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/BollingerStrategy.java
@@ -1,0 +1,48 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.sma;
+
+public class BollingerStrategy implements Strategy {
+    @Override
+    public String getName() { return "BollingerBands"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int period = 20;
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDrawdown = 0.0;
+
+        for (int i = period; i < prices.size(); i++) {
+            double ma = sma(prices, i, period);
+            double sd = 0.0;
+            for (int j = i - period + 1; j <= i; j++) {
+                double diff = prices.get(j) - ma;
+                sd += diff * diff;
+            }
+            sd = Math.sqrt(sd / period);
+            double upper = ma + 2 * sd;
+            double lower = ma - 2 * sd;
+            double price = prices.get(i);
+
+            if (price < lower && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (price > upper && position == 1) {
+                position = 0;
+                cash += price;
+            }
+
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity) / peak;
+            if (dd > maxDrawdown) maxDrawdown = dd;
+        }
+
+        double finalCapital = cash + position * prices.get(prices.size() - 1);
+        return new BacktestResult(finalCapital, maxDrawdown);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/BreakoutStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/BreakoutStrategy.java
@@ -1,0 +1,41 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.highest;
+import static com.backtester.strategy.IndicatorUtils.lowest;
+
+public class BreakoutStrategy implements Strategy {
+    @Override
+    public String getName() { return "Breakout"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int lookback = 20;
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+
+        for (int i = lookback; i < prices.size(); i++) {
+            double high = highest(prices, i-1, lookback);
+            double low = lowest(prices, i-1, lookback);
+            double price = prices.get(i);
+
+            if (price > high && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (price < low && position == 1) {
+                position = 0;
+                cash += price;
+            }
+
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity)/peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size()-1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/GoldenCrossStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/GoldenCrossStrategy.java
@@ -1,0 +1,41 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.sma;
+
+public class GoldenCrossStrategy implements Strategy {
+    @Override
+    public String getName() { return "Golden_Cross"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int fast = 50;
+        int slow = 200;
+        if (prices.size() < slow) return new BacktestResult(initialCapital, 0);
+
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+
+        for (int i = slow; i < prices.size(); i++) {
+            double fastMa = sma(prices, i, fast);
+            double slowMa = sma(prices, i, slow);
+            double price = prices.get(i);
+            if (fastMa > slowMa && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (fastMa < slowMa && position == 1) {
+                position = 0;
+                cash += price;
+            }
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity)/peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size()-1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/IndicatorUtils.java
+++ b/backend/src/main/java/com/backtester/strategy/IndicatorUtils.java
@@ -1,0 +1,79 @@
+package com.backtester.strategy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IndicatorUtils {
+    public static double sma(List<Double> prices, int index, int period) {
+        double sum = 0.0;
+        for (int i = index - period + 1; i <= index; i++) {
+            sum += prices.get(i);
+        }
+        return sum / period;
+    }
+
+    public static List<Double> ema(List<Double> prices, int period) {
+        List<Double> out = new ArrayList<>();
+        double k = 2.0 / (period + 1);
+        double prev = prices.get(0);
+        out.add(prev);
+        for (int i = 1; i < prices.size(); i++) {
+            prev = prices.get(i) * k + prev * (1 - k);
+            out.add(prev);
+        }
+        return out;
+    }
+
+    public static double rsi(List<Double> prices, int index, int period) {
+        double gain = 0.0;
+        double loss = 0.0;
+        for (int i = index - period + 1; i <= index; i++) {
+            double diff = prices.get(i) - prices.get(i - 1);
+            if (diff > 0) gain += diff; else loss -= diff;
+        }
+        double avgGain = gain / period;
+        double avgLoss = loss / period;
+        if (avgLoss == 0) {
+            return 100.0;
+        }
+        double rs = avgGain / avgLoss;
+        return 100.0 - (100.0 / (1 + rs));
+    }
+
+    public static double highest(List<Double> prices, int index, int lookback) {
+        double max = Double.NEGATIVE_INFINITY;
+        for (int i = index - lookback + 1; i <= index; i++) {
+            if (prices.get(i) > max) max = prices.get(i);
+        }
+        return max;
+    }
+
+    public static double lowest(List<Double> prices, int index, int lookback) {
+        double min = Double.POSITIVE_INFINITY;
+        for (int i = index - lookback + 1; i <= index; i++) {
+            if (prices.get(i) < min) min = prices.get(i);
+        }
+        return min;
+    }
+
+    public static double adx(List<Double> prices, int index, int period) {
+        if (index < period) return 0.0;
+        double up = 0.0;
+        double down = 0.0;
+        for (int i = index - period + 1; i <= index; i++) {
+            double diff = prices.get(i) - prices.get(i - 1);
+            if (diff > 0) up += diff; else down -= diff;
+        }
+        double sum = up + down;
+        if (sum == 0) return 0.0;
+        return Math.abs(up - down) / sum * 100.0;
+    }
+
+    public static double vwap(List<Double> prices, int index, int lookback) {
+        double total = 0.0;
+        for (int i = index - lookback + 1; i <= index; i++) {
+            total += prices.get(i);
+        }
+        return total / lookback;
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/MACDCrossStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/MACDCrossStrategy.java
@@ -1,0 +1,46 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.ema;
+
+public class MACDCrossStrategy implements Strategy {
+    @Override
+    public String getName() { return "MACD_CROSS"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        if (prices.size() < 35) return new BacktestResult(initialCapital, 0);
+
+        List<Double> ema12 = ema(prices, 12);
+        List<Double> ema26 = ema(prices, 26);
+        List<Double> macd = new java.util.ArrayList<>();
+        for (int i = 0; i < prices.size(); i++) {
+            macd.add(ema12.get(i) - ema26.get(i));
+        }
+        List<Double> signal = ema(macd, 9);
+
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+        for (int i = 1; i < prices.size(); i++) {
+            double prev = macd.get(i-1) - signal.get(i-1);
+            double cur = macd.get(i) - signal.get(i);
+            double price = prices.get(i);
+            if (cur > 0 && prev <= 0 && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (cur < 0 && prev >= 0 && position == 1) {
+                position = 0;
+                cash += price;
+            }
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity) / peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size()-1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/MACDHistogramStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/MACDHistogramStrategy.java
@@ -1,0 +1,47 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.ema;
+
+public class MACDHistogramStrategy implements Strategy {
+    @Override
+    public String getName() { return "MACD_Hist"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        if (prices.size() < 35) return new BacktestResult(initialCapital, 0);
+
+        List<Double> ema12 = ema(prices, 12);
+        List<Double> ema26 = ema(prices, 26);
+        List<Double> macd = new java.util.ArrayList<>();
+        for (int i = 0; i < prices.size(); i++) {
+            macd.add(ema12.get(i) - ema26.get(i));
+        }
+        List<Double> signal = ema(macd, 9);
+
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+
+        for (int i = 1; i < prices.size(); i++) {
+            double histPrev = macd.get(i-1) - signal.get(i-1);
+            double hist = macd.get(i) - signal.get(i);
+            double price = prices.get(i);
+            if (hist > 0 && histPrev <= 0 && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (hist < 0 && histPrev >= 0 && position == 1) {
+                position = 0;
+                cash += price;
+            }
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity)/peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size()-1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/MACDStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/MACDStrategy.java
@@ -1,0 +1,59 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.ema;
+
+public class MACDStrategy implements Strategy {
+    @Override
+    public String getName() { return "MACD"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        if (prices.size() < 35) {
+            return new BacktestResult(initialCapital, 0);
+        }
+
+        List<Double> ema12 = ema(prices, 12);
+        List<Double> ema26 = ema(prices, 26);
+
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDrawdown = 0.0;
+        double prevMacd = 0;
+        double prevSignal = 0;
+
+        // compute MACD and signal on the fly
+        List<Double> macdValues = new java.util.ArrayList<>();
+        for (int i = 0; i < prices.size(); i++) {
+            macdValues.add(ema12.get(i) - ema26.get(i));
+        }
+        List<Double> signal = ema(macdValues, 9);
+
+        for (int i = 1; i < prices.size(); i++) {
+            double macd = macdValues.get(i);
+            double sig = signal.get(i);
+            double price = prices.get(i);
+
+            if (macd > sig && prevMacd <= prevSignal && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (macd < sig && prevMacd >= prevSignal && position == 1) {
+                position = 0;
+                cash += price;
+            }
+
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity) / peak;
+            if (dd > maxDrawdown) maxDrawdown = dd;
+
+            prevMacd = macd;
+            prevSignal = sig;
+        }
+
+        double finalCapital = cash + position * prices.get(prices.size() - 1);
+        return new BacktestResult(finalCapital, maxDrawdown);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/MeanReversionVWAPStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/MeanReversionVWAPStrategy.java
@@ -1,0 +1,37 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.vwap;
+
+public class MeanReversionVWAPStrategy implements Strategy {
+    @Override
+    public String getName() { return "Mean_VWAP"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int lookback = 20;
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+
+        for (int i = lookback; i < prices.size(); i++) {
+            double vw = vwap(prices, i, lookback);
+            double price = prices.get(i);
+            if (price < vw * 0.98 && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (price > vw * 1.02 && position == 1) {
+                position = 0;
+                cash += price;
+            }
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity)/peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size()-1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/MovingAverageRibbonStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/MovingAverageRibbonStrategy.java
@@ -1,0 +1,41 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.ema;
+
+public class MovingAverageRibbonStrategy implements Strategy {
+    @Override
+    public String getName() { return "MA_Ribbon"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int[] periods = {8, 13, 21};
+        List<Double> ema1 = ema(prices, periods[0]);
+        List<Double> ema2 = ema(prices, periods[1]);
+        List<Double> ema3 = ema(prices, periods[2]);
+
+        int start = periods[2];
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+
+        for (int i = start; i < prices.size(); i++) {
+            double price = prices.get(i);
+            if (ema1.get(i) > ema2.get(i) && ema2.get(i) > ema3.get(i) && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (!(ema1.get(i) > ema2.get(i) && ema2.get(i) > ema3.get(i)) && position == 1) {
+                position = 0;
+                cash += price;
+            }
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity)/peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size()-1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/OpeningRangeBreakoutStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/OpeningRangeBreakoutStrategy.java
@@ -1,0 +1,41 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.highest;
+import static com.backtester.strategy.IndicatorUtils.lowest;
+
+public class OpeningRangeBreakoutStrategy implements Strategy {
+    @Override
+    public String getName() { return "Opening_Range"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int rangePeriod = 30; // first 30 bars
+        if (prices.size() <= rangePeriod) return new BacktestResult(initialCapital, 0);
+        double high = highest(prices, rangePeriod - 1, rangePeriod);
+        double low = lowest(prices, rangePeriod - 1, rangePeriod);
+
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+
+        for (int i = rangePeriod; i < prices.size(); i++) {
+            double price = prices.get(i);
+            if (price > high && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (price < low && position == 1) {
+                position = 0;
+                cash += price;
+            }
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity)/peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size()-1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/RSIEMABounceStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/RSIEMABounceStrategy.java
@@ -1,0 +1,42 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.*;
+
+public class RSIEMABounceStrategy implements Strategy {
+    @Override
+    public String getName() { return "RSI_EMA"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int rsiPeriod = 14;
+        int emaPeriod = 20;
+        List<Double> emaList = ema(prices, emaPeriod);
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+
+        for (int i = Math.max(rsiPeriod, emaPeriod); i < prices.size(); i++) {
+            double r = rsi(prices, i, rsiPeriod);
+            double emaVal = emaList.get(i);
+            double price = prices.get(i);
+
+            if (r < 30 && price > emaVal && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (r > 70 && price < emaVal && position == 1) {
+                position = 0;
+                cash += price;
+            }
+
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity)/peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size()-1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/RSISMACrossoverStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/RSISMACrossoverStrategy.java
@@ -1,0 +1,41 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.*;
+
+public class RSISMACrossoverStrategy implements Strategy {
+    @Override
+    public String getName() { return "RSI_SMA"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int rsiPeriod = 14;
+        int smaPeriod = 50;
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+
+        for (int i = Math.max(rsiPeriod, smaPeriod); i < prices.size(); i++) {
+            double r = rsi(prices, i, rsiPeriod);
+            double ma = sma(prices, i, smaPeriod);
+            double price = prices.get(i);
+
+            if (r < 30 && price > ma && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if ((r > 70 || price < ma) && position == 1) {
+                position = 0;
+                cash += price;
+            }
+
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity) / peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size() - 1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/RSIStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/RSIStrategy.java
@@ -1,0 +1,61 @@
+package com.backtester.strategy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.rsi;
+
+public class RSIStrategy implements Strategy {
+    @Override
+    public String getName() { return "RSI"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int period = 14;
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDrawdown = 0.0;
+        List<Trade> trades = new ArrayList<>();
+        List<Double> equity = new ArrayList<>();
+        Trade openTrade = null;
+
+        for (int i = period; i < prices.size(); i++) {
+            double price = prices.get(i);
+            double r = rsi(prices, i, period);
+            if (r < 30 && position == 0) {
+                position = 1;
+                cash -= price;
+                openTrade = new Trade(i, price);
+            } else if (r > 70 && position == 1) {
+                position = 0;
+                cash += price;
+                if (openTrade != null) {
+                    openTrade.setExit(i, price);
+                    trades.add(openTrade);
+                    openTrade = null;
+                }
+            }
+            double eq = cash + position * price;
+            equity.add(eq);
+            if (eq > peak) {
+                peak = eq;
+            }
+            double dd = (peak - eq) / peak;
+            if (dd > maxDrawdown) {
+                maxDrawdown = dd;
+            }
+        }
+
+        double finalCapital = cash + position * prices.get(prices.size() - 1);
+        if (openTrade != null) {
+            openTrade.setExit(prices.size() - 1, prices.get(prices.size() - 1));
+            trades.add(openTrade);
+        }
+        BacktestResult result = new BacktestResult(finalCapital, maxDrawdown);
+        result.setTrades(trades);
+        result.setEquityCurve(equity);
+        result.setInitialCapital(initialCapital);
+        return result;
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/ScalpingSupertrendStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/ScalpingSupertrendStrategy.java
@@ -1,0 +1,39 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.sma;
+
+public class ScalpingSupertrendStrategy implements Strategy {
+    @Override
+    public String getName() { return "Scalp_Supertrend"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int fast = 5;
+        int slow = 10;
+        if (prices.size() < slow) return new BacktestResult(initialCapital, 0);
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+        for (int i = slow; i < prices.size(); i++) {
+            double fastMa = sma(prices, i, fast);
+            double slowMa = sma(prices, i, slow);
+            double price = prices.get(i);
+            if (fastMa > slowMa && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (fastMa < slowMa && position == 1) {
+                position = 0;
+                cash += price;
+            }
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity)/peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size()-1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/Strategy.java
+++ b/backend/src/main/java/com/backtester/strategy/Strategy.java
@@ -1,0 +1,8 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+public interface Strategy {
+    String getName();
+    BacktestResult run(List<Double> prices, double initialCapital);
+}

--- a/backend/src/main/java/com/backtester/strategy/SupertrendStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/SupertrendStrategy.java
@@ -1,0 +1,46 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.sma;
+
+public class SupertrendStrategy implements Strategy {
+    @Override
+    public String getName() { return "Supertrend"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int fast = 10;
+        int slow = 30;
+        if (prices.size() < slow) {
+            return new BacktestResult(initialCapital, 0);
+        }
+
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDrawdown = 0.0;
+
+        for (int i = slow; i < prices.size(); i++) {
+            double fastMa = sma(prices, i, fast);
+            double slowMa = sma(prices, i, slow);
+            double price = prices.get(i);
+
+            if (fastMa > slowMa && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (fastMa < slowMa && position == 1) {
+                position = 0;
+                cash += price;
+            }
+
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity) / peak;
+            if (dd > maxDrawdown) maxDrawdown = dd;
+        }
+
+        double finalCapital = cash + position * prices.get(prices.size() - 1);
+        return new BacktestResult(finalCapital, maxDrawdown);
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/Trade.java
+++ b/backend/src/main/java/com/backtester/strategy/Trade.java
@@ -1,0 +1,23 @@
+package com.backtester.strategy;
+
+public class Trade {
+    private int entryIndex;
+    private double entryPrice;
+    private int exitIndex;
+    private double exitPrice;
+
+    public Trade(int entryIndex, double entryPrice) {
+        this.entryIndex = entryIndex;
+        this.entryPrice = entryPrice;
+    }
+
+    public void setExit(int exitIndex, double exitPrice) {
+        this.exitIndex = exitIndex;
+        this.exitPrice = exitPrice;
+    }
+
+    public int getEntryIndex() { return entryIndex; }
+    public double getEntryPrice() { return entryPrice; }
+    public int getExitIndex() { return exitIndex; }
+    public double getExitPrice() { return exitPrice; }
+}

--- a/backend/src/main/java/com/backtester/strategy/VWAPPullbackStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/VWAPPullbackStrategy.java
@@ -1,0 +1,37 @@
+package com.backtester.strategy;
+
+import java.util.List;
+
+import static com.backtester.strategy.IndicatorUtils.vwap;
+
+public class VWAPPullbackStrategy implements Strategy {
+    @Override
+    public String getName() { return "VWAP_Pullback"; }
+
+    @Override
+    public BacktestResult run(List<Double> prices, double initialCapital) {
+        int lookback = 20;
+        double cash = initialCapital;
+        int position = 0;
+        double peak = initialCapital;
+        double maxDD = 0.0;
+
+        for (int i = lookback; i < prices.size(); i++) {
+            double vw = vwap(prices, i, lookback);
+            double price = prices.get(i);
+            if (price < vw && position == 0) {
+                position = 1;
+                cash -= price;
+            } else if (price > vw && position == 1) {
+                position = 0;
+                cash += price;
+            }
+            double equity = cash + position * price;
+            if (equity > peak) peak = equity;
+            double dd = (peak - equity)/peak;
+            if (dd > maxDD) maxDD = dd;
+        }
+        double finalCap = cash + position * prices.get(prices.size()-1);
+        return new BacktestResult(finalCap, maxDD);
+    }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Backtester</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="container py-3">
+<h1 class="mb-4">Backtester</h1>
+<form id="runForm" class="row g-2 mb-4">
+    <div class="col-md-3">
+        <label class="form-label">Strategy
+            <select name="strategy" id="strategy" class="form-select">
+                <option>RSI</option>
+                <option>MACD</option>
+                <option>BollingerBands</option>
+                <option>Supertrend</option>
+                <option>RSI_SMA</option>
+                <option>MACD_CROSS</option>
+                <option>Bollinger_Reversal</option>
+                <option>Golden_Cross</option>
+                <option>Breakout</option>
+                <option>ADX_DI</option>
+                <option>VWAP_Pullback</option>
+                <option>RSI_EMA</option>
+                <option>MACD_Hist</option>
+                <option>Opening_Range</option>
+                <option>Scalp_Supertrend</option>
+                <option>MA_Ribbon</option>
+                <option>Mean_VWAP</option>
+            </select>
+        </label>
+    </div>
+    <div class="col-md-2">
+        <label class="form-label">Symbol
+            <input type="text" name="symbol" id="symbol" value="RELIANCE" class="form-control" />
+        </label>
+    </div>
+    <div class="col-md-2">
+        <label class="form-label">Period
+            <select name="period" id="period" class="form-select">
+                <option value="1m">1m</option>
+                <option value="5m">5m</option>
+                <option value="30m">30m</option>
+                <option value="1d" selected>1d</option>
+                <option value="1w">1w</option>
+            </select>
+        </label>
+    </div>
+    <div class="col-md-2">
+        <label class="form-label">From
+            <input type="date" name="from" id="from" class="form-control" />
+        </label>
+    </div>
+    <div class="col-md-2">
+        <label class="form-label">To
+            <input type="date" name="to" id="to" class="form-control" />
+        </label>
+    </div>
+    <div class="col-md-2">
+        <label class="form-label">Initial Capital
+            <input type="number" name="capital" id="capital" value="100000" class="form-control" />
+        </label>
+    </div>
+    <div class="col-12">
+        <button class="btn btn-primary" type="submit">Run</button>
+    </div>
+</form>
+
+<div id="summary" class="mb-3"></div>
+<canvas id="chart" height="300"></canvas>
+
+<h2 class="mt-4">History</h2>
+<ul id="history" class="list-group"></ul>
+
+<script>
+    let chart;
+
+    async function loadHistory() {
+        const res = await fetch('/api/backtest/history');
+        const hist = await res.json();
+        const ul = document.getElementById('history');
+        ul.innerHTML = '';
+        hist.forEach(h => {
+            const li = document.createElement('li');
+            li.className = 'list-group-item';
+            li.textContent = h;
+            ul.appendChild(li);
+        });
+    }
+
+    function drawChart(candles, trades) {
+        const labels = candles.map(c => c.time);
+        const prices = candles.map(c => c.close);
+        const buy = trades.map(t => ({x: t.entryIndex, y: prices[t.entryIndex]}));
+        const sell = trades.map(t => ({x: t.exitIndex, y: prices[t.exitIndex]}));
+        const ctx = document.getElementById('chart').getContext('2d');
+        if (chart) chart.destroy();
+        chart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels,
+                datasets: [
+                    {label: 'Close', data: prices, borderColor: 'blue', fill: false},
+                    {label: 'Buy', data: buy, pointBackgroundColor: 'green', type: 'scatter', pointRadius: 5},
+                    {label: 'Sell', data: sell, pointBackgroundColor: 'red', type: 'scatter', pointRadius: 5}
+                ]
+            },
+            options: { scales: { x: { display: false } } }
+        });
+    }
+
+    document.getElementById('runForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const params = new URLSearchParams(new FormData(e.target));
+        const res = await fetch('/api/backtest?' + params.toString());
+        const data = await res.json();
+        document.getElementById('summary').innerHTML =
+            `Initial: ${data.initialCapital} Final: ${data.finalCapital} ` +
+            `Profit: ${data.profitPercent.toFixed(2)}% Drawdown: ${(data.maxDrawdown*100).toFixed(2)}%`;
+        drawChart(data.candles || [], data.trades || []);
+        loadHistory();
+    });
+
+    loadHistory();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- return full candle list and trade info in `BacktestResult`
- track trades and equity in `RSIStrategy`
- expose candles via controller and record initial capital
- style frontend with Bootstrap and plot results using Chart.js
- document the new UI features

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841e46a9d208323ad6c18d5520a73a7