### PR TITLE
Improve backtest UI with chart and trade details

### DIFF
--- a/backend/src/main/java/com/backtester/controller/BacktestController.java
+++ b/backend/src/main/java/com/backtester/controller/BacktestController.java
@@ -35,7 +35,8 @@ public class BacktestController {
         }
         List<Double> prices = quoteService.getPrices(symbol, period, from, to);
         BacktestResult result = strat.run(prices, capital);
-        historyService.add(strategy + " " + symbol + " => " + result.getFinalCapital());
+        double profitPct = (result.getFinalCapital() - result.getInitialCapital()) / result.getInitialCapital() * 100.0;
+        historyService.add(String.format("%s %s %.2f%%", strategy, symbol, profitPct));
         return result;
     }
 

--- a/backend/src/main/java/com/backtester/strategy/ADXDIStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/ADXDIStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.*;
@@ -15,6 +16,7 @@ public class ADXDIStrategy implements Strategy {
         int position = 0;
         double peak = initialCapital;
         double maxDD = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = period; i < prices.size(); i++) {
             double adxVal = adx(prices, i, period);
@@ -26,9 +28,11 @@ public class ADXDIStrategy implements Strategy {
             if (adxVal > 25 && diPlus && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (adxVal > 25 && !diPlus && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
 
             double equity = cash + position * price;
@@ -37,6 +41,6 @@ public class ADXDIStrategy implements Strategy {
             if (dd > maxDD) maxDD = dd;
         }
         double finalCap = cash + position * prices.get(prices.size()-1);
-        return new BacktestResult(finalCap, maxDD);
+        return new BacktestResult(initialCapital, finalCap, maxDD, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/BacktestResult.java
+++ b/backend/src/main/java/com/backtester/strategy/BacktestResult.java
@@ -1,12 +1,25 @@
 package com.backtester.strategy;
 
+import java.util.List;
+
 public class BacktestResult {
+    private double initialCapital;
     private double finalCapital;
     private double maxDrawdown;
+    private List<Double> prices;
+    private List<Trade> trades;
 
-    public BacktestResult(double finalCapital, double maxDrawdown) {
+    public BacktestResult(double initialCapital, double finalCapital, double maxDrawdown,
+                          List<Double> prices, List<Trade> trades) {
+        this.initialCapital = initialCapital;
         this.finalCapital = finalCapital;
         this.maxDrawdown = maxDrawdown;
+        this.prices = prices;
+        this.trades = trades;
+    }
+
+    public double getInitialCapital() {
+        return initialCapital;
     }
 
     public double getFinalCapital() {
@@ -15,5 +28,13 @@ public class BacktestResult {
 
     public double getMaxDrawdown() {
         return maxDrawdown;
+    }
+
+    public List<Double> getPrices() {
+        return prices;
+    }
+
+    public List<Trade> getTrades() {
+        return trades;
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/BollingerReversalStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/BollingerReversalStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.sma;
@@ -15,6 +16,7 @@ public class BollingerReversalStrategy implements Strategy {
         int position = 0;
         double peak = initialCapital;
         double maxDD = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = period; i < prices.size(); i++) {
             double ma = sma(prices, i, period);
@@ -31,9 +33,11 @@ public class BollingerReversalStrategy implements Strategy {
             if (price < lower && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (price > upper && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
 
             double equity = cash + position * price;
@@ -42,6 +46,6 @@ public class BollingerReversalStrategy implements Strategy {
             if (dd > maxDD) maxDD = dd;
         }
         double finalCap = cash + position * prices.get(prices.size() - 1);
-        return new BacktestResult(finalCap, maxDD);
+        return new BacktestResult(initialCapital, finalCap, maxDD, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/BollingerStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/BollingerStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.sma;
@@ -15,6 +16,7 @@ public class BollingerStrategy implements Strategy {
         int position = 0;
         double peak = initialCapital;
         double maxDrawdown = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = period; i < prices.size(); i++) {
             double ma = sma(prices, i, period);
@@ -31,9 +33,11 @@ public class BollingerStrategy implements Strategy {
             if (price < lower && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (price > upper && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
 
             double equity = cash + position * price;
@@ -43,6 +47,6 @@ public class BollingerStrategy implements Strategy {
         }
 
         double finalCapital = cash + position * prices.get(prices.size() - 1);
-        return new BacktestResult(finalCapital, maxDrawdown);
+        return new BacktestResult(initialCapital, finalCapital, maxDrawdown, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/BreakoutStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/BreakoutStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.highest;
@@ -16,6 +17,7 @@ public class BreakoutStrategy implements Strategy {
         int position = 0;
         double peak = initialCapital;
         double maxDD = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = lookback; i < prices.size(); i++) {
             double high = highest(prices, i-1, lookback);
@@ -25,9 +27,11 @@ public class BreakoutStrategy implements Strategy {
             if (price > high && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (price < low && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
 
             double equity = cash + position * price;
@@ -36,6 +40,6 @@ public class BreakoutStrategy implements Strategy {
             if (dd > maxDD) maxDD = dd;
         }
         double finalCap = cash + position * prices.get(prices.size()-1);
-        return new BacktestResult(finalCap, maxDD);
+        return new BacktestResult(initialCapital, finalCap, maxDD, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/GoldenCrossStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/GoldenCrossStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.sma;
@@ -12,12 +13,14 @@ public class GoldenCrossStrategy implements Strategy {
     public BacktestResult run(List<Double> prices, double initialCapital) {
         int fast = 50;
         int slow = 200;
-        if (prices.size() < slow) return new BacktestResult(initialCapital, 0);
+        if (prices.size() < slow)
+            return new BacktestResult(initialCapital, initialCapital, 0, prices, new ArrayList<>());
 
         double cash = initialCapital;
         int position = 0;
         double peak = initialCapital;
         double maxDD = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = slow; i < prices.size(); i++) {
             double fastMa = sma(prices, i, fast);
@@ -26,9 +29,11 @@ public class GoldenCrossStrategy implements Strategy {
             if (fastMa > slowMa && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (fastMa < slowMa && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
             double equity = cash + position * price;
             if (equity > peak) peak = equity;
@@ -36,6 +41,6 @@ public class GoldenCrossStrategy implements Strategy {
             if (dd > maxDD) maxDD = dd;
         }
         double finalCap = cash + position * prices.get(prices.size()-1);
-        return new BacktestResult(finalCap, maxDD);
+        return new BacktestResult(initialCapital, finalCap, maxDD, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/MACDHistogramStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/MACDHistogramStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.ema;
@@ -10,7 +11,8 @@ public class MACDHistogramStrategy implements Strategy {
 
     @Override
     public BacktestResult run(List<Double> prices, double initialCapital) {
-        if (prices.size() < 35) return new BacktestResult(initialCapital, 0);
+        if (prices.size() < 35)
+            return new BacktestResult(initialCapital, initialCapital, 0, prices, new ArrayList<>());
 
         List<Double> ema12 = ema(prices, 12);
         List<Double> ema26 = ema(prices, 26);
@@ -24,6 +26,7 @@ public class MACDHistogramStrategy implements Strategy {
         int position = 0;
         double peak = initialCapital;
         double maxDD = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = 1; i < prices.size(); i++) {
             double histPrev = macd.get(i-1) - signal.get(i-1);
@@ -32,9 +35,11 @@ public class MACDHistogramStrategy implements Strategy {
             if (hist > 0 && histPrev <= 0 && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (hist < 0 && histPrev >= 0 && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
             double equity = cash + position * price;
             if (equity > peak) peak = equity;
@@ -42,6 +47,6 @@ public class MACDHistogramStrategy implements Strategy {
             if (dd > maxDD) maxDD = dd;
         }
         double finalCap = cash + position * prices.get(prices.size()-1);
-        return new BacktestResult(finalCap, maxDD);
+        return new BacktestResult(initialCapital, finalCap, maxDD, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/MACDStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/MACDStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.ema;
@@ -11,7 +12,7 @@ public class MACDStrategy implements Strategy {
     @Override
     public BacktestResult run(List<Double> prices, double initialCapital) {
         if (prices.size() < 35) {
-            return new BacktestResult(initialCapital, 0);
+            return new BacktestResult(initialCapital, initialCapital, 0, prices, new ArrayList<>());
         }
 
         List<Double> ema12 = ema(prices, 12);
@@ -21,6 +22,7 @@ public class MACDStrategy implements Strategy {
         int position = 0;
         double peak = initialCapital;
         double maxDrawdown = 0.0;
+        List<Trade> trades = new ArrayList<>();
         double prevMacd = 0;
         double prevSignal = 0;
 
@@ -39,9 +41,11 @@ public class MACDStrategy implements Strategy {
             if (macd > sig && prevMacd <= prevSignal && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (macd < sig && prevMacd >= prevSignal && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
 
             double equity = cash + position * price;
@@ -54,6 +58,6 @@ public class MACDStrategy implements Strategy {
         }
 
         double finalCapital = cash + position * prices.get(prices.size() - 1);
-        return new BacktestResult(finalCapital, maxDrawdown);
+        return new BacktestResult(initialCapital, finalCapital, maxDrawdown, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/MeanReversionVWAPStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/MeanReversionVWAPStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.vwap;
@@ -15,6 +16,7 @@ public class MeanReversionVWAPStrategy implements Strategy {
         int position = 0;
         double peak = initialCapital;
         double maxDD = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = lookback; i < prices.size(); i++) {
             double vw = vwap(prices, i, lookback);
@@ -22,9 +24,11 @@ public class MeanReversionVWAPStrategy implements Strategy {
             if (price < vw * 0.98 && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (price > vw * 1.02 && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
             double equity = cash + position * price;
             if (equity > peak) peak = equity;
@@ -32,6 +36,6 @@ public class MeanReversionVWAPStrategy implements Strategy {
             if (dd > maxDD) maxDD = dd;
         }
         double finalCap = cash + position * prices.get(prices.size()-1);
-        return new BacktestResult(finalCap, maxDD);
+        return new BacktestResult(initialCapital, finalCap, maxDD, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/MovingAverageRibbonStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/MovingAverageRibbonStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.ema;
@@ -20,15 +21,18 @@ public class MovingAverageRibbonStrategy implements Strategy {
         int position = 0;
         double peak = initialCapital;
         double maxDD = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = start; i < prices.size(); i++) {
             double price = prices.get(i);
             if (ema1.get(i) > ema2.get(i) && ema2.get(i) > ema3.get(i) && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (!(ema1.get(i) > ema2.get(i) && ema2.get(i) > ema3.get(i)) && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
             double equity = cash + position * price;
             if (equity > peak) peak = equity;
@@ -36,6 +40,6 @@ public class MovingAverageRibbonStrategy implements Strategy {
             if (dd > maxDD) maxDD = dd;
         }
         double finalCap = cash + position * prices.get(prices.size()-1);
-        return new BacktestResult(finalCap, maxDD);
+        return new BacktestResult(initialCapital, finalCap, maxDD, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/RSIEMABounceStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/RSIEMABounceStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.*;
@@ -17,6 +18,7 @@ public class RSIEMABounceStrategy implements Strategy {
         int position = 0;
         double peak = initialCapital;
         double maxDD = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = Math.max(rsiPeriod, emaPeriod); i < prices.size(); i++) {
             double r = rsi(prices, i, rsiPeriod);
@@ -26,9 +28,11 @@ public class RSIEMABounceStrategy implements Strategy {
             if (r < 30 && price > emaVal && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (r > 70 && price < emaVal && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
 
             double equity = cash + position * price;
@@ -37,6 +41,6 @@ public class RSIEMABounceStrategy implements Strategy {
             if (dd > maxDD) maxDD = dd;
         }
         double finalCap = cash + position * prices.get(prices.size()-1);
-        return new BacktestResult(finalCap, maxDD);
+        return new BacktestResult(initialCapital, finalCap, maxDD, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/RSISMACrossoverStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/RSISMACrossoverStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.*;
@@ -16,6 +17,7 @@ public class RSISMACrossoverStrategy implements Strategy {
         int position = 0;
         double peak = initialCapital;
         double maxDD = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = Math.max(rsiPeriod, smaPeriod); i < prices.size(); i++) {
             double r = rsi(prices, i, rsiPeriod);
@@ -25,9 +27,11 @@ public class RSISMACrossoverStrategy implements Strategy {
             if (r < 30 && price > ma && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if ((r > 70 || price < ma) && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
 
             double equity = cash + position * price;
@@ -36,6 +40,6 @@ public class RSISMACrossoverStrategy implements Strategy {
             if (dd > maxDD) maxDD = dd;
         }
         double finalCap = cash + position * prices.get(prices.size() - 1);
-        return new BacktestResult(finalCap, maxDD);
+        return new BacktestResult(initialCapital, finalCap, maxDD, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/RSIStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/RSIStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.rsi;
@@ -15,6 +16,7 @@ public class RSIStrategy implements Strategy {
         int position = 0;
         double peak = initialCapital;
         double maxDrawdown = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = period; i < prices.size(); i++) {
             double price = prices.get(i);
@@ -22,9 +24,11 @@ public class RSIStrategy implements Strategy {
             if (r < 30 && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (r > 70 && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
             double equity = cash + position * price;
             if (equity > peak) {
@@ -37,6 +41,6 @@ public class RSIStrategy implements Strategy {
         }
 
         double finalCapital = cash + position * prices.get(prices.size() - 1);
-        return new BacktestResult(finalCapital, maxDrawdown);
+        return new BacktestResult(initialCapital, finalCapital, maxDrawdown, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/ScalpingSupertrendStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/ScalpingSupertrendStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.sma;
@@ -12,11 +13,13 @@ public class ScalpingSupertrendStrategy implements Strategy {
     public BacktestResult run(List<Double> prices, double initialCapital) {
         int fast = 5;
         int slow = 10;
-        if (prices.size() < slow) return new BacktestResult(initialCapital, 0);
+        if (prices.size() < slow)
+            return new BacktestResult(initialCapital, initialCapital, 0, prices, new ArrayList<>());
         double cash = initialCapital;
         int position = 0;
         double peak = initialCapital;
         double maxDD = 0.0;
+        List<Trade> trades = new ArrayList<>();
         for (int i = slow; i < prices.size(); i++) {
             double fastMa = sma(prices, i, fast);
             double slowMa = sma(prices, i, slow);
@@ -24,9 +27,11 @@ public class ScalpingSupertrendStrategy implements Strategy {
             if (fastMa > slowMa && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (fastMa < slowMa && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
             double equity = cash + position * price;
             if (equity > peak) peak = equity;
@@ -34,6 +39,6 @@ public class ScalpingSupertrendStrategy implements Strategy {
             if (dd > maxDD) maxDD = dd;
         }
         double finalCap = cash + position * prices.get(prices.size()-1);
-        return new BacktestResult(finalCap, maxDD);
+        return new BacktestResult(initialCapital, finalCap, maxDD, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/SupertrendStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/SupertrendStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.sma;
@@ -13,13 +14,14 @@ public class SupertrendStrategy implements Strategy {
         int fast = 10;
         int slow = 30;
         if (prices.size() < slow) {
-            return new BacktestResult(initialCapital, 0);
+            return new BacktestResult(initialCapital, initialCapital, 0, prices, new ArrayList<>());
         }
 
         double cash = initialCapital;
         int position = 0;
         double peak = initialCapital;
         double maxDrawdown = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = slow; i < prices.size(); i++) {
             double fastMa = sma(prices, i, fast);
@@ -29,9 +31,11 @@ public class SupertrendStrategy implements Strategy {
             if (fastMa > slowMa && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (fastMa < slowMa && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
 
             double equity = cash + position * price;
@@ -41,6 +45,6 @@ public class SupertrendStrategy implements Strategy {
         }
 
         double finalCapital = cash + position * prices.get(prices.size() - 1);
-        return new BacktestResult(finalCapital, maxDrawdown);
+        return new BacktestResult(initialCapital, finalCapital, maxDrawdown, prices, trades);
     }
 }

--- a/backend/src/main/java/com/backtester/strategy/Trade.java
+++ b/backend/src/main/java/com/backtester/strategy/Trade.java
@@ -1,0 +1,25 @@
+package com.backtester.strategy;
+
+public class Trade {
+    private int index;
+    private double price;
+    private String side;
+
+    public Trade(int index, double price, String side) {
+        this.index = index;
+        this.price = price;
+        this.side = side;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public String getSide() {
+        return side;
+    }
+}

--- a/backend/src/main/java/com/backtester/strategy/VWAPPullbackStrategy.java
+++ b/backend/src/main/java/com/backtester/strategy/VWAPPullbackStrategy.java
@@ -1,5 +1,6 @@
 package com.backtester.strategy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.backtester.strategy.IndicatorUtils.vwap;
@@ -15,6 +16,7 @@ public class VWAPPullbackStrategy implements Strategy {
         int position = 0;
         double peak = initialCapital;
         double maxDD = 0.0;
+        List<Trade> trades = new ArrayList<>();
 
         for (int i = lookback; i < prices.size(); i++) {
             double vw = vwap(prices, i, lookback);
@@ -22,9 +24,11 @@ public class VWAPPullbackStrategy implements Strategy {
             if (price < vw && position == 0) {
                 position = 1;
                 cash -= price;
+                trades.add(new Trade(i, price, "BUY"));
             } else if (price > vw && position == 1) {
                 position = 0;
                 cash += price;
+                trades.add(new Trade(i, price, "SELL"));
             }
             double equity = cash + position * price;
             if (equity > peak) peak = equity;
@@ -32,6 +36,6 @@ public class VWAPPullbackStrategy implements Strategy {
             if (dd > maxDD) maxDD = dd;
         }
         double finalCap = cash + position * prices.get(prices.size()-1);
-        return new BacktestResult(finalCap, maxDD);
+        return new BacktestResult(initialCapital, finalCap, maxDD, prices, trades);
     }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,46 +2,78 @@
 <html>
 <head>
     <title>Backtester</title>
-    <style>
-        body { font-family: Arial; padding:20px; }
-    </style>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>body { padding:40px; }</style>
 </head>
 <body>
-<h1>Backtester</h1>
-<form id="runForm">
-    <label>Strategy:
-        <select name="strategy" id="strategy">
-            <option>RSI</option>
-            <option>MACD</option>
-            <option>BollingerBands</option>
-            <option>Supertrend</option>
-            <option>RSI_SMA</option>
-            <option>MACD_CROSS</option>
-            <option>Bollinger_Reversal</option>
-            <option>Golden_Cross</option>
-            <option>Breakout</option>
-            <option>ADX_DI</option>
-            <option>VWAP_Pullback</option>
-            <option>RSI_EMA</option>
-            <option>MACD_Hist</option>
-            <option>Opening_Range</option>
-            <option>Scalp_Supertrend</option>
-            <option>MA_Ribbon</option>
-            <option>Mean_VWAP</option>
-        </select>
-    </label><br/>
-    <label>Symbol: <input type="text" name="symbol" id="symbol" value="RELIANCE"/></label><br/>
-    <label>Period: <input type="text" name="period" id="period" value="1d"/></label><br/>
-    <label>From: <input type="date" name="from" id="from"/></label><br/>
-    <label>To: <input type="date" name="to" id="to"/></label><br/>
-    <label>Initial Capital: <input type="number" name="capital" id="capital" value="100000"/></label><br/>
-    <button type="submit">Run</button>
+<div class="container">
+<h1 class="title">Backtester</h1>
+<form id="runForm" class="box">
+    <div class="field">
+        <label class="label">Strategy</label>
+        <div class="control">
+            <select name="strategy" id="strategy" class="select">
+                <option>RSI</option>
+                <option>MACD</option>
+                <option>BollingerBands</option>
+                <option>Supertrend</option>
+                <option>RSI_SMA</option>
+                <option>MACD_CROSS</option>
+                <option>Bollinger_Reversal</option>
+                <option>Golden_Cross</option>
+                <option>Breakout</option>
+                <option>ADX_DI</option>
+                <option>VWAP_Pullback</option>
+                <option>RSI_EMA</option>
+                <option>MACD_Hist</option>
+                <option>Opening_Range</option>
+                <option>Scalp_Supertrend</option>
+                <option>MA_Ribbon</option>
+                <option>Mean_VWAP</option>
+            </select>
+        </div>
+    </div>
+    <div class="field">
+        <label class="label">Symbol</label>
+        <div class="control"><input class="input" type="text" name="symbol" id="symbol" value="RELIANCE"></div>
+    </div>
+    <div class="field">
+        <label class="label">Period</label>
+        <div class="control">
+            <select name="period" id="period" class="select">
+                <option>1d</option>
+                <option>1m</option>
+                <option>5m</option>
+                <option>30m</option>
+                <option>1w</option>
+            </select>
+        </div>
+    </div>
+    <div class="field">
+        <label class="label">From</label>
+        <div class="control"><input class="input" type="date" name="from" id="from"></div>
+    </div>
+    <div class="field">
+        <label class="label">To</label>
+        <div class="control"><input class="input" type="date" name="to" id="to"></div>
+    </div>
+    <div class="field">
+        <label class="label">Initial Capital</label>
+        <div class="control"><input class="input" type="number" name="capital" id="capital" value="100000"></div>
+    </div>
+    <div class="control"><button class="button is-primary" type="submit">Run</button></div>
 </form>
-<pre id="result"></pre>
-<h2>History</h2>
+
+<div id="summary" class="content"></div>
+<canvas id="chart" height="300"></canvas>
+
+<h2 class="title is-4">History</h2>
 <ul id="history"></ul>
+</div>
 
 <script>
+    let chart;
     async function loadHistory() {
         const res = await fetch('/api/backtest/history');
         const hist = await res.json();
@@ -54,12 +86,30 @@
         });
     }
 
+    function renderChart(prices, trades) {
+        const ctx = document.getElementById('chart');
+        if(chart) chart.destroy();
+        const labels = prices.map((_,i)=>i+1);
+        const datasets = [{label:'Price', data:prices, borderColor:'blue', fill:false}];
+        if(trades.length) {
+            datasets.push({
+                type:'scatter',
+                label:'Trades',
+                data: trades.map(t => ({x:t.index+1, y:t.price, side:t.side})),
+                backgroundColor: trades.map(t=>t.side==='BUY'?'green':'red')
+            });
+        }
+        chart = new Chart(ctx,{type:'line',data:{labels,datasets},options:{plugins:{tooltip:{callbacks:{label:(ctx)=>{return ctx.raw.side?ctx.raw.side+': '+ctx.raw.y:ctx.parsed.y;}}}}}});
+    }
+
     document.getElementById('runForm').addEventListener('submit', async (e) => {
         e.preventDefault();
         const params = new URLSearchParams(new FormData(e.target));
         const res = await fetch('/api/backtest?' + params.toString());
         const data = await res.json();
-        document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+        const pct = ((data.finalCapital - data.initialCapital)/data.initialCapital*100).toFixed(2);
+        document.getElementById('summary').innerHTML = `<p>Initial: ${data.initialCapital.toFixed(2)}</p><p>Final: ${data.finalCapital.toFixed(2)}</p><p>Profit/Loss: ${pct}%</p>`;
+        renderChart(data.prices, data.trades);
         loadHistory();
     });
 


### PR DESCRIPTION
## Summary
- add Trade class and extend BacktestResult with prices and trades
- track buy/sell trades inside all strategies
- show percent profit in history log
- enhance frontend with Bulma styling, dropdowns and Chart.js graph

## Testing
- `apt-get update -qq && apt-get install -y maven`
- `mvn -q package` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_6841efb47e80832392c29bdc6551d12a