### PR TITLE
Improve README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This project provides a Java Spring Boot backend and a React frontend for running trading strategy backtests using data from the Zerodha KITE API. Price data is cached in Redis to avoid redundant requests. A small in-memory history is kept for previous runs.
 
+## Prerequisites
+
+ - Java 8 or later with Maven
+- Node.js 18+ and npm
+- Python 3.11+ (for `rss_monitor.py`)
+- A Redis server running on `localhost:6379`
+- API keys configured in `config.yaml` for Zerodha KITE (key, secret and redirect URI), OpenAI and Telegram
+
 ## Backend
 
 The backend is located in the `backend` directory. It exposes a REST endpoint `/api/backtest` that accepts strategy name, symbol, candle period (e.g. `1d`, `1m`, `5m`, `30m`, `1w`), date range and initial capital. Supported strategies now cover a wide selection including:
@@ -14,6 +22,13 @@ The backend is located in the `backend` directory. It exposes a REST endpoint `/
 All algorithms operate on any candle period provided.
 
 Price quotes are fetched from Zerodha KITE in `QuoteService` and cached in Redis and an in-memory map. Credentials are read from `config.yaml`. History of executed backtests can be retrieved from `/api/backtest/history`.
+
+Before starting the backend, update `config.yaml` with your personal API keys and ensure Redis is running. During development the application can be started with:
+
+```bash
+cd backend
+mvn spring-boot:run
+```
 
 ## Frontend
 
@@ -36,20 +51,35 @@ npx serve -s dist
 
 ## Building
 
-This is a standard Maven project:
+This is a standard Maven project targeting Java 8:
 
 ```bash
 cd backend
 mvn package
 ```
 
-Running the Spring Boot application will serve the API on `localhost:8080`.
+The generated JAR can be started with:
+
+```bash
+java -jar target/*.jar
+```
+
+The API will then be available on `localhost:8080`.
+
+## Zerodha Login
+
+Set `kite_api_key`, `kite_api_secret` and `kite_redirect_uri` in `config.yaml`.
+After starting the backend visit `http://localhost:5173/login` (during
+development) and click **Login with Zerodha**. Complete the OAuth flow and the
+backend will store the returned access token in memory.
 
 ## RSS Monitor
 
 The `rss_monitor.py` script polls the feed defined in `config.yaml` every five minutes,
 analyzes new headlines with GPT-4 and stores the result in Redis. Summaries are
 also posted to the configured Telegram channel.
+
+Edit `config.yaml` with your OpenAI and Telegram credentials before running and make sure Redis is running.
 
 Install Python dependencies and run the monitor with:
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -6,7 +6,7 @@
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
-        <java.version>11</java.version>
+        <java.version>1.8</java.version>
         <spring.boot.version>2.7.3</spring.boot.version>
     </properties>
     <dependencyManagement>
@@ -43,6 +43,15 @@
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/backend/src/main/java/com/backtester/Config.java
+++ b/backend/src/main/java/com/backtester/Config.java
@@ -24,4 +24,8 @@ public class Config {
         Object v = values.get(key);
         return v == null ? null : v.toString();
     }
+
+    public static void set(String key, String value) {
+        values.put(key, value);
+    }
 }

--- a/backend/src/main/java/com/backtester/controller/AuthController.java
+++ b/backend/src/main/java/com/backtester/controller/AuthController.java
@@ -1,0 +1,71 @@
+package com.backtester.controller;
+
+import com.backtester.Config;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.security.MessageDigest;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+    @GetMapping("/login")
+    public void login(HttpServletResponse response) throws IOException {
+        String apiKey = Config.get("kite_api_key");
+        String redirect = Config.get("kite_redirect_uri");
+        String url = String.format(
+                "https://kite.zerodha.com/connect/login?v=3&api_key=%s&redirect_uri=%s",
+                apiKey,
+                URLEncoder.encode(redirect, "UTF-8"));
+        response.sendRedirect(url);
+    }
+
+    @GetMapping("/callback")
+    public String callback(@RequestParam("request_token") String token) throws IOException {
+        String apiKey = Config.get("kite_api_key");
+        String secret = Config.get("kite_api_secret");
+        String checksum = sha256(apiKey + token + secret);
+        String body = String.format("api_key=%s&request_token=%s&checksum=%s", apiKey, token, checksum);
+        URL url = new URL("https://api.kite.trade/session/token");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+        conn.setDoOutput(true);
+        OutputStream os = conn.getOutputStream();
+        os.write(body.getBytes("UTF-8"));
+        os.flush();
+        os.close();
+        if (conn.getResponseCode() != 200) {
+            return "Failed to authenticate";
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(conn.getInputStream());
+        String access = root.path("data").path("access_token").asText();
+        Config.set("kite_access_token", access);
+        return "Authentication successful";
+    }
+
+    private String sha256(String text) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = md.digest(text.getBytes("UTF-8"));
+            StringBuilder sb = new StringBuilder();
+            for (byte b : bytes) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,8 @@ telegram_chat_id: "YOUR_CHAT_ID"
 rss_feed_url: "https://www.moneycontrol.com/rss/markets.xml"
 kite_api_key: "YOUR_KITE_API_KEY"
 kite_access_token: "YOUR_KITE_ACCESS_TOKEN"
+kite_api_secret: "YOUR_KITE_API_SECRET"
+kite_redirect_uri: "http://localhost:8080/api/auth/callback"
 # default investment amount by confidence score 1-10
 confidence_investment:
   1: 0

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default function Login() {
+  const start = () => {
+    window.location.href = '/api/auth/login'
+  }
+  return (
+    <div className="h-screen flex items-center justify-center bg-gray-100 dark:bg-gray-900">
+      <button onClick={start} className="px-4 py-2 bg-blue-600 text-white rounded">Login with Zerodha</button>
+    </div>
+  )
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
+import Login from './Login.jsx'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root')).render(
+const root = document.getElementById('root')
+const path = window.location.pathname
+ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <App />
+    {path.startsWith('/login') ? <Login /> : <App />}
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- expand README with prerequisites
- document config setup and running the backend
- document jar execution and RSS monitor requirements
- make backend Java 8 compatible
- add OAuth login page for Zerodha

## Testing
- `pytest -q`
- `mvn -q -f backend/pom.xml test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fce3a8ac832382b9f16152f9dae3