### PR TITLE
Implement sentiment feed UI table

### DIFF
--- a/backend/src/main/java/com/backtester/controller/FeedController.java
+++ b/backend/src/main/java/com/backtester/controller/FeedController.java
@@ -1,0 +1,49 @@
+package com.backtester.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import redis.clients.jedis.Jedis;
+
+import java.util.*;
+
+@RestController
+@RequestMapping("/api/feed")
+public class FeedController {
+    private final Jedis jedis = new Jedis("localhost");
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @GetMapping
+    public List<Map<String, Object>> list() {
+        Set<String> keys = jedis.keys("headline:*");
+        List<Map<String, Object>> out = new ArrayList<>();
+        for (String k : keys) {
+            try {
+                Map<String, Object> val = mapper.readValue(jedis.get(k), Map.class);
+                val.put("id", k.substring("headline:".length()));
+                double close = 0.0;
+                if (val.containsKey("close")) {
+                    close = ((Number) val.get("close")).doubleValue();
+                }
+                double current = close + (Math.random() - 0.5) * close * 0.02;
+                val.put("current", current);
+                String action = "";
+                if (val.containsKey("analysis")) {
+                    Object a = ((Map<?, ?>) val.get("analysis")).get("action");
+                    if (a != null) action = a.toString();
+                }
+                double pct = close != 0 ? (current - close) / close * 100.0 : 0.0;
+                if ("sell".equalsIgnoreCase(action)) pct *= -1;
+                val.put("changePct", pct);
+                out.add(val);
+            } catch (Exception ignored) {
+            }
+        }
+        out.sort((a, b) -> Double.compare(
+                ((Number) b.getOrDefault("timestamp", 0)).doubleValue(),
+                ((Number) a.getOrDefault("timestamp", 0)).doubleValue()));
+        return out;
+    }
+}
+

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import ResultCard from './ResultCard.jsx'
+import SentimentTable from './SentimentTable.jsx'
 
 function ConfidenceTable() {
   const stored = JSON.parse(localStorage.getItem('confidence_investment') || '{}')
@@ -113,6 +114,7 @@ export default function Dashboard() {
       </form>
       <ResultCard result={result} />
       <ConfidenceTable />
+      <SentimentTable />
     </div>
   )
 }

--- a/frontend/src/components/SentimentTable.jsx
+++ b/frontend/src/components/SentimentTable.jsx
@@ -1,0 +1,94 @@
+import React, { useState, useEffect } from 'react'
+
+export default function SentimentTable() {
+  const [items, setItems] = useState([])
+  const [amounts, setAmounts] = useState({})
+  const [trades, setTrades] = useState(() => JSON.parse(localStorage.getItem('trades') || '{}'))
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch('/api/feed')
+      const data = await res.json()
+      setItems(data)
+      const conf = JSON.parse(localStorage.getItem('confidence_investment') || '{}')
+      setAmounts(prev => {
+        const next = { ...prev }
+        data.forEach(it => {
+          const c = Math.round(it.analysis?.confidence || 0)
+          if (next[it.id] === undefined) next[it.id] = conf[c] || 0
+        })
+        return next
+      })
+    }
+    load()
+    const id = setInterval(load, 30000)
+    return () => clearInterval(id)
+  }, [])
+
+  const updateAmount = (id, val) => {
+    setAmounts({ ...amounts, [id]: val })
+  }
+
+  const execute = (it) => {
+    const t = { action: it.analysis?.action || 'Buy', amount: Number(amounts[it.id] || 0), price: it.current }
+    const next = { ...trades, [it.id]: t }
+    setTrades(next)
+    localStorage.setItem('trades', JSON.stringify(next))
+  }
+
+  const liveStatus = (it) => {
+    const t = trades[it.id]
+    if (!t) return '-'
+    const diff = (it.current - t.price) / t.price * (t.action.toLowerCase() === 'sell' ? -1 : 1)
+    return (diff * 100).toFixed(2) + '%'
+  }
+
+  const bookedPct = (it) => {
+    const action = it.analysis?.action || 'Buy'
+    const diff = (it.current - it.close) / it.close * (action.toLowerCase() === 'sell' ? -1 : 1)
+    return (diff * 100).toFixed(2) + '%'
+  }
+
+  return (
+    <div className="mt-4">
+      <h3 className="font-semibold mb-2">Sentiment Signals</h3>
+      <div className="overflow-x-auto">
+        <table className="table-auto w-full text-sm">
+          <thead>
+            <tr>
+              <th className="px-2">Feed</th>
+              <th className="px-2">Rating</th>
+              <th className="px-2">Close</th>
+              <th className="px-2">Current</th>
+              <th className="px-2">P&L</th>
+              <th className="px-2">Amount</th>
+              <th className="px-2">Trade</th>
+              <th className="px-2">Live</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map(it => (
+              <tr key={it.id} className="odd:bg-gray-50 dark:odd:bg-gray-700">
+                <td className="p-2">{it.title}</td>
+                <td className="p-2 text-center">{it.analysis?.action}</td>
+                <td className="p-2 text-right">{it.close?.toFixed(2)}</td>
+                <td className="p-2 text-right">{it.current?.toFixed(2)}</td>
+                <td className="p-2 text-right">{bookedPct(it)}</td>
+                <td className="p-2">
+                  <input type="number" className="w-full p-1 border rounded dark:bg-gray-800" value={amounts[it.id] || ''} onChange={e => updateAmount(it.id, e.target.value)} />
+                </td>
+                <td className="p-2 text-center">
+                  <button onClick={() => execute(it)} className="px-2 py-1 bg-green-600 text-white rounded">
+                    {it.analysis?.action}
+                  </button>
+                </td>
+                <td className="p-2 text-right">{liveStatus(it)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+

--- a/rss_monitor.py
+++ b/rss_monitor.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import time
+import random
 
 import feedparser
 import openai
@@ -44,7 +45,13 @@ def process_entry(entry):
         data = json.loads(text)
     except json.JSONDecodeError:
         data = {"error": "Failed to parse", "raw": text}
-    stored = {"title": entry.title, "link": entry.link, "analysis": data}
+    stored = {
+        "title": entry.title,
+        "link": entry.link,
+        "analysis": data,
+        "timestamp": time.time(),
+        "close": round(90 + random.random() * 20, 2),
+    }
     r.set(f"headline:{h}", json.dumps(stored))
     send_telegram(f"{entry.title}\n{json.dumps(data, ensure_ascii=False)}")
 


### PR DESCRIPTION
## Summary
- store timestamp and random close price in `rss_monitor.py`
- expose `/api/feed` endpoint to serve processed RSS data
- show sentiment trading table in React frontend

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842799c95b08323809885fd757f8be0