### PR TITLE
Fix Jedis URI initialization

### DIFF
--- a/backend/src/main/java/com/backtester/controller/FeedController.java
+++ b/backend/src/main/java/com/backtester/controller/FeedController.java
@@ -11,7 +11,8 @@ import java.util.*;
 @RestController
 @RequestMapping("/api/feed")
 public class FeedController {
-    private final Jedis jedis = new Jedis("localhost");
+    // Jedis(String) expects a redis URI; provide host and port explicitly
+    private final Jedis jedis = new Jedis("redis://localhost:6379");
     private final ObjectMapper mapper = new ObjectMapper();
 
     @GetMapping

--- a/backend/src/main/java/com/backtester/service/QuoteService.java
+++ b/backend/src/main/java/com/backtester/service/QuoteService.java
@@ -16,7 +16,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class QuoteService {
-    private final Jedis jedis = new Jedis("localhost");
+    // Jedis(String) expects a redis URI starting with redis://
+    private final Jedis jedis = new Jedis("redis://localhost:6379");
     private final Map<String, List<Double>> memoryCache = new ConcurrentHashMap<>();
 
     public List<Double> getPrices(String symbol, String period, String from, String to) {


### PR DESCRIPTION
## Summary
- configure Jedis with a valid redis URI in FeedController and QuoteService

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684291f7f49883239bd4403f133b6730