### PR TITLE
Improve Redis error handling

### DIFF
--- a/backend/src/main/java/com/backtester/controller/BacktestController.java
+++ b/backend/src/main/java/com/backtester/controller/BacktestController.java
@@ -5,6 +5,10 @@ import com.backtester.service.QuoteService;
 import com.backtester.service.StrategyFactory;
 import com.backtester.strategy.BacktestResult;
 import com.backtester.strategy.Strategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,6 +19,7 @@ public class BacktestController {
     private final QuoteService quoteService;
     private final StrategyFactory strategyFactory;
     private final HistoryService historyService;
+    private static final Logger logger = LoggerFactory.getLogger(BacktestController.class);
 
     public BacktestController(QuoteService quoteService, StrategyFactory strategyFactory, HistoryService historyService) {
         this.quoteService = quoteService;
@@ -23,21 +28,32 @@ public class BacktestController {
     }
 
     @GetMapping
-    public BacktestResult run(@RequestParam String strategy,
-                              @RequestParam String symbol,
-                              @RequestParam String period,
-                              @RequestParam String from,
-                              @RequestParam String to,
-                              @RequestParam double capital) {
+    public ResponseEntity<?> run(@RequestParam String strategy,
+                                 @RequestParam String symbol,
+                                 @RequestParam String period,
+                                 @RequestParam String from,
+                                 @RequestParam String to,
+                                 @RequestParam double capital) {
         Strategy strat = strategyFactory.getStrategy(strategy);
         if (strat == null) {
-            throw new IllegalArgumentException("Unknown strategy: " + strategy);
+            return ResponseEntity.badRequest().body(
+                    java.util.Collections.singletonMap("error", "Unknown strategy: " + strategy));
         }
-        List<Double> prices = quoteService.getPrices(symbol, period, from, to);
-        BacktestResult result = strat.run(prices, capital);
-        double profitPct = (result.getFinalCapital() - result.getInitialCapital()) / result.getInitialCapital() * 100.0;
-        historyService.add(String.format("%s %s %.2f%%", strategy, symbol, profitPct));
-        return result;
+        try {
+            List<Double> prices = quoteService.getPrices(symbol, period, from, to);
+            BacktestResult result = strat.run(prices, capital);
+            double profitPct = (result.getFinalCapital() - result.getInitialCapital()) / result.getInitialCapital() * 100.0;
+            historyService.add(String.format("%s %s %.2f%%", strategy, symbol, profitPct));
+            return ResponseEntity.ok(result);
+        } catch (IllegalStateException e) {
+            logger.error("Redis access error", e);
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body(java.util.Map.of("error", "Redis not available", "message", e.getMessage()));
+        } catch (Exception e) {
+            logger.error("Error running backtest", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(java.util.Map.of("error", e.getMessage()));
+        }
     }
 
     @GetMapping("/history")

--- a/backend/src/main/java/com/backtester/controller/FeedController.java
+++ b/backend/src/main/java/com/backtester/controller/FeedController.java
@@ -1,6 +1,10 @@
 package com.backtester.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,37 +18,47 @@ public class FeedController {
     // Jedis(String) expects a redis URI; provide host and port explicitly
     private final Jedis jedis = new Jedis("redis://localhost:6379");
     private final ObjectMapper mapper = new ObjectMapper();
+    private static final Logger logger = LoggerFactory.getLogger(FeedController.class);
 
     @GetMapping
-    public List<Map<String, Object>> list() {
-        Set<String> keys = jedis.keys("headline:*");
-        List<Map<String, Object>> out = new ArrayList<>();
-        for (String k : keys) {
-            try {
-                Map<String, Object> val = mapper.readValue(jedis.get(k), Map.class);
-                val.put("id", k.substring("headline:".length()));
-                double close = 0.0;
-                if (val.containsKey("close")) {
-                    close = ((Number) val.get("close")).doubleValue();
+    public ResponseEntity<?> list() {
+        try {
+            Set<String> keys = jedis.keys("headline:*");
+            List<Map<String, Object>> out = new ArrayList<>();
+            for (String k : keys) {
+                try {
+                    Map<String, Object> val = mapper.readValue(jedis.get(k), Map.class);
+                    val.put("id", k.substring("headline:".length()));
+                    double close = 0.0;
+                    if (val.containsKey("close")) {
+                        close = ((Number) val.get("close")).doubleValue();
+                    }
+                    double current = close + (Math.random() - 0.5) * close * 0.02;
+                    val.put("current", current);
+                    String action = "";
+                    if (val.containsKey("analysis")) {
+                        Object a = ((Map<?, ?>) val.get("analysis")).get("action");
+                        if (a != null) action = a.toString();
+                    }
+                    double pct = close != 0 ? (current - close) / close * 100.0 : 0.0;
+                    if ("sell".equalsIgnoreCase(action)) pct *= -1;
+                    val.put("changePct", pct);
+                    out.add(val);
+                } catch (Exception e) {
+                    logger.warn("Failed to parse entry {}", k, e);
                 }
-                double current = close + (Math.random() - 0.5) * close * 0.02;
-                val.put("current", current);
-                String action = "";
-                if (val.containsKey("analysis")) {
-                    Object a = ((Map<?, ?>) val.get("analysis")).get("action");
-                    if (a != null) action = a.toString();
-                }
-                double pct = close != 0 ? (current - close) / close * 100.0 : 0.0;
-                if ("sell".equalsIgnoreCase(action)) pct *= -1;
-                val.put("changePct", pct);
-                out.add(val);
-            } catch (Exception ignored) {
             }
+            out.sort((a, b) -> Double.compare(
+                    ((Number) b.getOrDefault("timestamp", 0)).doubleValue(),
+                    ((Number) a.getOrDefault("timestamp", 0)).doubleValue()));
+            return ResponseEntity.ok(out);
+        } catch (Exception e) {
+            logger.error("Failed to fetch feed from redis", e);
+            Map<String, String> err = new HashMap<>();
+            err.put("error", "Redis not available");
+            err.put("message", e.getMessage());
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(err);
         }
-        out.sort((a, b) -> Double.compare(
-                ((Number) b.getOrDefault("timestamp", 0)).doubleValue(),
-                ((Number) a.getOrDefault("timestamp", 0)).doubleValue()));
-        return out;
     }
 }
 


### PR DESCRIPTION
## Summary
- improve error handling in FeedController and BacktestController
- add logging and propagate Redis errors in QuoteService
- update rss_monitor with logging and Redis connection checks

## Testing
- `python -m py_compile rss_monitor.py`
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684296841f30832399672accb75101e3