### PR TITLE
Fix Zerodha login issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ During development run:
 cd frontend
 npm install
 npm run dev
+# The dev server proxies all `/api` requests to `http://localhost:8080`,
+# so make sure the Spring Boot backend is running.
 ```
 
 For deployment (e.g. on a DigitalOcean VM) build the static files and serve the
@@ -69,9 +71,10 @@ The API will then be available on `localhost:8080`.
 ## Zerodha Login
 
 Set `kite_api_key`, `kite_api_secret` and `kite_redirect_uri` in `config.yaml`.
-After starting the backend visit `http://localhost:5173/login` (during
-development) and click **Login with Zerodha**. Complete the OAuth flow and the
-backend will store the returned access token in memory.
+Start the Spring Boot backend and the Vite dev server as described above.
+Then open `http://localhost:5173/login` and click **Login with Zerodha** to begin
+the OAuth flow. On success the backend stores the returned access token in
+memory for subsequent API calls.
 
 ## RSS Monitor
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:8080'
+    }
   }
 })


### PR DESCRIPTION
## Summary
- proxy API calls from the Vite dev server to the backend
- document how to run the dev servers and complete Zerodha login

## Testing
- `cd backend && mvn -q test` *(fails: `mvn: command not found`)*
- `cd frontend && npm test` *(fails: missing npm script)*

------
https://chatgpt.com/codex/tasks/task_e_68429e8dec8883239f7201cec7335956