### PR TITLE
Use Groq API for news sentiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ memory for subsequent API calls.
 ## RSS Monitor
 
 The `rss_monitor.py` script polls the feed defined in `config.yaml` every five minutes,
-analyzes new headlines with GPT-4 and stores the result in Redis. Summaries are
-also posted to the configured Telegram channel.
+analyzes new headlines with the Groq API and stores the result in Redis. Each analysis
+includes affected NSE tokens, a buy or sell recommendation with a confidence score
+and whether the effect is short or long term. Summaries are also posted to the configured Telegram channel.
 
-Edit `config.yaml` with your OpenAI and Telegram credentials before running and make sure Redis is running.
+Edit `config.yaml` with your Groq API key and Telegram credentials before running and make sure Redis is running.
 
 Install Python dependencies and run the monitor with:
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 openai_api_key: "YOUR_OPENAI_API_KEY"
+groq_api_key: "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"
 telegram_token: "YOUR_TELEGRAM_TOKEN"
 telegram_chat_id: "YOUR_CHAT_ID"
 rss_feed_url: "https://www.moneycontrol.com/rss/markets.xml"

--- a/frontend/src/components/SentimentTable.jsx
+++ b/frontend/src/components/SentimentTable.jsx
@@ -57,7 +57,10 @@ export default function SentimentTable() {
           <thead>
             <tr>
               <th className="px-2">Feed</th>
-              <th className="px-2">Rating</th>
+              <th className="px-2">Tokens</th>
+              <th className="px-2">Action</th>
+              <th className="px-2">Conf</th>
+              <th className="px-2">Term</th>
               <th className="px-2">Close</th>
               <th className="px-2">Current</th>
               <th className="px-2">P&L</th>
@@ -70,7 +73,10 @@ export default function SentimentTable() {
             {items.map(it => (
               <tr key={it.id} className="odd:bg-gray-50 dark:odd:bg-gray-700">
                 <td className="p-2">{it.title}</td>
+                <td className="p-2">{(it.analysis?.tokens || []).join(', ')}</td>
                 <td className="p-2 text-center">{it.analysis?.action}</td>
+                <td className="p-2 text-center">{it.analysis?.confidence}</td>
+                <td className="p-2 text-center">{it.analysis?.term}</td>
                 <td className="p-2 text-right">{it.close?.toFixed(2)}</td>
                 <td className="p-2 text-right">{it.current?.toFixed(2)}</td>
                 <td className="p-2 text-right">{bookedPct(it)}</td>

--- a/rss_monitor.py
+++ b/rss_monitor.py
@@ -12,7 +12,8 @@ import yaml
 
 CONFIG = yaml.safe_load(open('config.yaml'))
 
-openai.api_key = CONFIG.get('openai_api_key')
+openai.api_key = CONFIG.get('groq_api_key')
+openai.base_url = "https://api.groq.com/openai/v1"
 TELEGRAM_TOKEN = CONFIG.get('telegram_token')
 TELEGRAM_CHAT = CONFIG.get('telegram_chat_id')
 RSS_URL = CONFIG.get('rss_feed_url')
@@ -23,9 +24,10 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 PROMPT = (
-    "Analyze this news for trading sentiment: '{title} - {description}'. "
-    "Return JSON with: company, sentiment (positive/neutral/negative), action "
-    "(Buy/Hold/Sell), reason. Get confidence score on a scale of 10."
+    "Analyze this news item and respond with JSON. "
+    "Fields: tokens (list of affected NSE symbols), action (Buy or Sell), "
+    "confidence (0-10), term ('short' or 'long' for expected profit horizon), "
+    "reason. Use concise JSON only. News: '{title} - {description}'."
 )
 
 


### PR DESCRIPTION
## Summary
- use Groq API for news sentiment analysis
- display NSE tokens, confidence and term on the sentiment table
- document Groq-powered sentiment monitor in README
- add Groq API key to config

## Testing
- `python rss_monitor.py` *(fails: no output within 5s)*
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842a30d64848323b441febe806a22e4