### PR TITLE
Expose Vite dev server and update Zerodha redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,13 @@ The API will then be available on `localhost:8080`.
 ## Zerodha Login
 
 Set `kite_api_key`, `kite_api_secret` and `kite_redirect_uri` in `config.yaml`.
-Start the Spring Boot backend and the Vite dev server as described above.
-Then open `http://localhost:5173/login` and click **Login with Zerodha** to begin
-the OAuth flow. On success the backend stores the returned access token in
-memory for subsequent API calls.
+If you want to access the portal from other machines set `host: '0.0.0.0'` in
+`frontend/vite.config.js` and update `kite_redirect_uri` to match your public
+IP or domain (e.g. `http://172.232.119.157:8080/api/auth/callback`). Restart the
+Spring Boot backend and the Vite dev server after making these changes. Then
+open `http://<your-ip>:5173/login` and click **Login with Zerodha** to begin the
+OAuth flow. On success the backend stores the returned access token in memory
+for subsequent API calls.
 
 ## RSS Monitor
 

--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ rss_feed_url: "https://www.moneycontrol.com/rss/markets.xml"
 kite_api_key: "s5clm4cvdoidnpbt"
 kite_access_token: "YOUR_KITE_ACCESS_TOKEN"
 kite_api_secret: "zrinp2au5txiq0bgs6sggxsg95ajtnzh"
-kite_redirect_uri: "http://localhost:8080/api/auth/callback"
+kite_redirect_uri: "http://172.232.119.157:8080/api/auth/callback"
 # user-provided application name for reference
 kite_app_name: "backtester"
 # default investment amount by confidence score 1-10

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: '0.0.0.0',
     port: 5173,
     proxy: {
       '/api': 'http://localhost:8080'


### PR DESCRIPTION
## Summary
- allow Vite dev server to bind on all interfaces
- update kite redirect URI for external access
- clarify Zerodha login steps

## Testing
- `npm install`
- `npm run build`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6842a623aaec8323a18457cb4c3c916d