### PR TITLE
Fix redirect url to use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The API will then be available on `localhost:8080`.
 Set `kite_api_key`, `kite_api_secret` and `kite_redirect_uri` in `config.yaml`.
 If you want to access the portal from other machines set `host: '0.0.0.0'` in
 `frontend/vite.config.js` and update `kite_redirect_uri` to match your public
-IP or domain (e.g. `http://172.232.119.157:8080/api/auth/callback`). Restart the
+IP or domain (e.g. `https://172.232.119.157:8080/api/auth/callback`). Restart the
 Spring Boot backend and the Vite dev server after making these changes. Then
 open `http://<your-ip>:5173/login` and click **Login with Zerodha** to begin the
 OAuth flow. On success the backend stores the returned access token in memory

--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ rss_feed_url: "https://www.moneycontrol.com/rss/markets.xml"
 kite_api_key: "s5clm4cvdoidnpbt"
 kite_access_token: "YOUR_KITE_ACCESS_TOKEN"
 kite_api_secret: "zrinp2au5txiq0bgs6sggxsg95ajtnzh"
-kite_redirect_uri: "http://172.232.119.157:8080/api/auth/callback"
+kite_redirect_uri: "https://172.232.119.157:8080/api/auth/callback"
 # user-provided application name for reference
 kite_app_name: "backtester"
 # default investment amount by confidence score 1-10


### PR DESCRIPTION
## Summary
- use https scheme in `kite_redirect_uri`
- update README example accordingly

## Testing
- `python -m py_compile rss_monitor.py`
- `npm run build` in `frontend`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6842a8d9860c8323bedb9ecbda802b75