### PR TITLE
Add config checks to login and tests

### DIFF
--- a/backend/src/test/java/com/backtester/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/backtester/controller/AuthControllerTest.java
@@ -1,0 +1,52 @@
+package com.backtester.controller;
+
+import com.backtester.Config;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private String origApiKey;
+    private String origRedirect;
+
+    @BeforeEach
+    void saveConfig() {
+        origApiKey = Config.get("kite_api_key");
+        origRedirect = Config.get("kite_redirect_uri");
+    }
+
+    @AfterEach
+    void restoreConfig() {
+        Config.set("kite_api_key", origApiKey);
+        Config.set("kite_redirect_uri", origRedirect);
+    }
+
+    @Test
+    void loginReturnsErrorWhenRedirectMissing() throws Exception {
+        Config.set("kite_api_key", "key");
+        Config.set("kite_redirect_uri", "");
+        mockMvc.perform(get("/api/auth/login"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json("{\"error\":\"kite_redirect_uri not configured\"}"));
+    }
+
+    @Test
+    void loginReturnsErrorWhenApiKeyMissing() throws Exception {
+        Config.set("kite_api_key", "");
+        Config.set("kite_redirect_uri", "http://example.com");
+        mockMvc.perform(get("/api/auth/login"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json("{\"error\":\"kite_api_key not configured\"}"));
+    }
+}


### PR DESCRIPTION
## Summary
- validate Kite API key and redirect URI in `AuthController.login`
- log and return an error JSON if required config is missing
- add unit tests for the error cases

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6842ab2d101c832382d7d94b9058af80