### PR TITLE
Handle missing config

### DIFF
--- a/backend/src/main/java/com/backtester/Config.java
+++ b/backend/src/main/java/com/backtester/Config.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 
 public class Config {
@@ -16,7 +15,7 @@ public class Config {
             ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
             values = mapper.readValue(new File("config.yaml"), Map.class);
         } catch (IOException e) {
-            values = Collections.emptyMap();
+            throw new RuntimeException("Failed to load config.yaml", e);
         }
     }
 


### PR DESCRIPTION
## Summary
- improve config handling by failing fast when `config.yaml` cannot be read

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842ab2ec5c48323a88916ce81ad5a70