### PR TITLE
Fix config loading path

### DIFF
--- a/backend/src/main/java/com/backtester/Config.java
+++ b/backend/src/main/java/com/backtester/Config.java
@@ -13,7 +13,11 @@ public class Config {
     static {
         try {
             ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-            values = mapper.readValue(new File("config.yaml"), Map.class);
+            File configFile = new File("config.yaml");
+            if (!configFile.exists()) {
+                configFile = new File("../config.yaml");
+            }
+            values = mapper.readValue(configFile, Map.class);
         } catch (IOException e) {
             throw new RuntimeException("Failed to load config.yaml", e);
         }


### PR DESCRIPTION
## Summary
- handle missing config.yaml when running from backend directory

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac9ae7208323ac936afe6267d2ec