### PR TITLE
Improve Kite auth callback

### DIFF
--- a/backend/src/main/java/com/backtester/Config.java
+++ b/backend/src/main/java/com/backtester/Config.java
@@ -6,14 +6,16 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
+import java.io.FileWriter;
 
 public class Config {
     private static Map<String, Object> values;
+    private static File configFile;
 
     static {
         try {
             ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-            File configFile = new File("config.yaml");
+            configFile = new File("config.yaml");
             if (!configFile.exists()) {
                 configFile = new File("../config.yaml");
             }
@@ -30,5 +32,17 @@ public class Config {
 
     public static void set(String key, String value) {
         values.put(key, value);
+    }
+
+    public static void save() {
+        if (configFile == null) return;
+        try {
+            ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+            try (FileWriter writer = new FileWriter(configFile)) {
+                mapper.writeValue(writer, values);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to save config.yaml", e);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- update auth callback to display HTML success/failure page
- persist captured access token back to `config.yaml`

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842ae03ee948323b28b6eca7a89c317