### PR TITLE
Fix backtest parameters and add access token validation

### DIFF
--- a/backend/src/main/java/com/backtester/controller/AuthController.java
+++ b/backend/src/main/java/com/backtester/controller/AuthController.java
@@ -74,6 +74,25 @@ public class AuthController {
         response.getWriter().write("<html><body><h1>" + message + "</h1></body></html>");
     }
 
+    @GetMapping("/check")
+    public java.util.Map<String, Boolean> check() {
+        String apiKey = Config.get("kite_api_key");
+        String access = Config.get("kite_access_token");
+        if (access == null || access.isEmpty()) {
+            return java.util.Map.of("valid", false);
+        }
+        try {
+            URL url = new URL(String.format("https://api.kite.trade/user/profile?api_key=%s&access_token=%s", apiKey, access));
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("X-Kite-Version", "3");
+            boolean ok = conn.getResponseCode() == 200;
+            return java.util.Map.of("valid", ok);
+        } catch (Exception e) {
+            return java.util.Map.of("valid", false);
+        }
+    }
+
     private String sha256(String text) {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-256");

--- a/backend/src/main/java/com/backtester/controller/BacktestController.java
+++ b/backend/src/main/java/com/backtester/controller/BacktestController.java
@@ -31,9 +31,17 @@ public class BacktestController {
     public ResponseEntity<?> run(@RequestParam String strategy,
                                  @RequestParam String symbol,
                                  @RequestParam String period,
-                                 @RequestParam String from,
-                                 @RequestParam String to,
+                                 @RequestParam(required = false, name = "from") String from,
+                                 @RequestParam(required = false, name = "start") String start,
+                                 @RequestParam(required = false, name = "to") String to,
+                                 @RequestParam(required = false, name = "end") String end,
                                  @RequestParam double capital) {
+        if (from == null) from = start;
+        if (to == null) to = end;
+        if (from == null || to == null) {
+            return ResponseEntity.badRequest().body(
+                    java.util.Collections.singletonMap("error", "Date range required"));
+        }
         Strategy strat = strategyFactory.getStrategy(strategy);
         if (strat == null) {
             return ResponseEntity.badRequest().body(

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,21 @@ export default function App() {
   useEffect(() => {
     document.documentElement.classList.toggle('dark', dark)
   }, [dark])
+
+  useEffect(() => {
+    async function verify() {
+      try {
+        const res = await fetch('/api/auth/check')
+        const data = await res.json()
+        if (!data.valid) {
+          window.location.href = '/login'
+        }
+      } catch (err) {
+        window.location.href = '/login'
+      }
+    }
+    verify()
+  }, [])
   return (
     <div className="flex h-screen">
       <Sidebar open={sidebar} onClose={() => setSidebar(false)} />


### PR DESCRIPTION
## Summary
- allow `start`/`end` query params in BacktestController
- provide `/api/auth/check` endpoint to verify Zerodha token
- verify token from frontend before rendering dashboard

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6842aeca80ec8323bc3f7be5835702a2