### PR TITLE
Fix auth callback redirect and use redis for tokens

### DIFF
--- a/backend/src/main/java/com/backtester/RedisStore.java
+++ b/backend/src/main/java/com/backtester/RedisStore.java
@@ -1,0 +1,28 @@
+package com.backtester;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+public class RedisStore {
+    private static final Logger logger = LoggerFactory.getLogger(RedisStore.class);
+    private static final Jedis jedis = new Jedis("redis://localhost:6379");
+
+    public static String get(String key) {
+        try {
+            return jedis.get(key);
+        } catch (JedisConnectionException e) {
+            logger.error("Redis not available", e);
+            return null;
+        }
+    }
+
+    public static void set(String key, String value) {
+        try {
+            jedis.set(key, value);
+        } catch (JedisConnectionException e) {
+            logger.error("Redis not available", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/backtester/service/QuoteService.java
+++ b/backend/src/main/java/com/backtester/service/QuoteService.java
@@ -3,6 +3,7 @@ package com.backtester.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.backtester.Config;
+import com.backtester.RedisStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -66,7 +67,7 @@ public class QuoteService {
 
     private List<Double> fetchFromKite(String symbol, String period, String from, String to) {
         String apiKey = Config.get("kite_api_key");
-        String accessToken = Config.get("kite_access_token");
+        String accessToken = RedisStore.get("kite_access_token");
         String url = String.format(
                 "https://api.kite.trade/instruments/historical/%s/%s?from=%s&to=%s&api_key=%s&access_token=%s",
                 symbol, period, from, to, apiKey, accessToken);


### PR DESCRIPTION
## Summary
- store auth tokens in redis via new `RedisStore` utility
- use `RedisStore` in `AuthController` and `QuoteService`
- redirect to home page after successful login

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: transfer failed)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842b1a3c1b08323a7022b305c4559e6