### PR TITLE
Use new auth validation endpoint

### DIFF
--- a/backend/src/main/java/com/backtester/controller/AuthController.java
+++ b/backend/src/main/java/com/backtester/controller/AuthController.java
@@ -106,6 +106,15 @@ public class AuthController {
         }
     }
 
+    @GetMapping("/validate")
+    public org.springframework.http.ResponseEntity<java.util.Map<String, Boolean>> validate() {
+        java.util.Map<String, Boolean> result = check();
+        if (Boolean.TRUE.equals(result.get("valid"))) {
+            return org.springframework.http.ResponseEntity.ok(result);
+        }
+        return org.springframework.http.ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).body(result);
+    }
+
     private String sha256(String text) {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-256");

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,7 +13,11 @@ export default function App() {
   useEffect(() => {
     async function verify() {
       try {
-        const res = await fetch('/api/auth/check')
+        const res = await fetch('/api/auth/validate')
+        if (!res.ok) {
+          window.location.href = '/login'
+          return
+        }
         const data = await res.json()
         if (!data.valid) {
           window.location.href = '/login'


### PR DESCRIPTION
## Summary
- update frontend auth check to call `/api/auth/validate`

## Testing
- `npm run build`
- `mvn -q -f backend/pom.xml test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_6842b63d203483239d512b11716ee6f9