### PR TITLE
Add configurable frontend URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ open `http://<your-ip>:5173/login` and click **Login with Zerodha** to begin the
 OAuth flow. On success the backend stores the returned access token in memory
 for subsequent API calls.
 
+Set `frontend_url` in `config.yaml` to the address where the React app is served
+(default `http://localhost:5173/`). The backend redirects here after successful
+authentication.
+
 ## RSS Monitor
 
 The `rss_monitor.py` script polls the feed defined in `config.yaml` every five minutes,

--- a/backend/src/main/java/com/backtester/Config.java
+++ b/backend/src/main/java/com/backtester/Config.java
@@ -20,6 +20,9 @@ public class Config {
                 configFile = new File("../config.yaml");
             }
             values = mapper.readValue(configFile, Map.class);
+            if (!values.containsKey("frontend_url")) {
+                values.put("frontend_url", "http://localhost:5173/");
+            }
         } catch (IOException e) {
             throw new RuntimeException("Failed to load config.yaml", e);
         }
@@ -27,7 +30,11 @@ public class Config {
 
     public static String get(String key) {
         Object v = values.get(key);
-        return v == null ? null : v.toString();
+        String val = v == null ? null : v.toString();
+        if ((val == null || val.isEmpty()) && "frontend_url".equals(key)) {
+            return "http://localhost:5173/";
+        }
+        return val;
     }
 
     public static void set(String key, String value) {

--- a/backend/src/main/java/com/backtester/controller/AuthController.java
+++ b/backend/src/main/java/com/backtester/controller/AuthController.java
@@ -80,7 +80,8 @@ public class AuthController {
             }
         }
         if ("Access token captured successfully".equals(message)) {
-            response.sendRedirect("/");
+            String home = Config.get("frontend_url");
+            response.sendRedirect(home != null && !home.isEmpty() ? home : "/");
         } else {
             response.setContentType("text/html");
             response.getWriter().write("<html><body><h1>" + message + "</h1></body></html>");

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,8 @@ kite_api_key: "s5clm4cvdoidnpbt"
 kite_access_token: "YOUR_KITE_ACCESS_TOKEN"
 kite_api_secret: "zrinp2au5txiq0bgs6sggxsg95ajtnzh"
 kite_redirect_uri: "https://172.232.119.157:8080/api/auth/callback"
+# URL of the React frontend used for redirects after login
+frontend_url: "http://localhost:5173/"
 # user-provided application name for reference
 kite_app_name: "backtester"
 # default investment amount by confidence score 1-10


### PR DESCRIPTION
## Summary
- add `frontend_url` entry in `config.yaml`
- return a default frontend URL from `Config`
- redirect to `frontend_url` after login instead of `/`
- document new configuration option in README

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842bc244140832393f7a834cfc0031f