### PR TITLE
Update frontend URL defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ If you want to access the portal from other machines set `host: '0.0.0.0'` in
 `frontend/vite.config.js` and update `kite_redirect_uri` to match your public
 IP or domain (e.g. `https://172.232.119.157:8080/api/auth/callback`). Restart the
 Spring Boot backend and the Vite dev server after making these changes. Then
-open `http://<your-ip>:5173/login` and click **Login with Zerodha** to begin the
+open `http://172.232.119.157:5173/login` and click **Login with Zerodha** to begin the
 OAuth flow. On success the backend stores the returned access token in memory
 for subsequent API calls.
 
 Set `frontend_url` in `config.yaml` to the address where the React app is served
-(default `http://localhost:5173/`). The backend redirects here after successful
+(default `http://172.232.119.157:5173/`). The backend redirects here after successful
 authentication.
 
 ## RSS Monitor

--- a/backend/src/main/java/com/backtester/Config.java
+++ b/backend/src/main/java/com/backtester/Config.java
@@ -21,7 +21,7 @@ public class Config {
             }
             values = mapper.readValue(configFile, Map.class);
             if (!values.containsKey("frontend_url")) {
-                values.put("frontend_url", "http://localhost:5173/");
+                values.put("frontend_url", "http://172.232.119.157:5173/");
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to load config.yaml", e);
@@ -32,7 +32,7 @@ public class Config {
         Object v = values.get(key);
         String val = v == null ? null : v.toString();
         if ((val == null || val.isEmpty()) && "frontend_url".equals(key)) {
-            return "http://localhost:5173/";
+            return "http://172.232.119.157:5173/";
         }
         return val;
     }

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ kite_access_token: "YOUR_KITE_ACCESS_TOKEN"
 kite_api_secret: "zrinp2au5txiq0bgs6sggxsg95ajtnzh"
 kite_redirect_uri: "https://172.232.119.157:8080/api/auth/callback"
 # URL of the React frontend used for redirects after login
-frontend_url: "http://localhost:5173/"
+frontend_url: "http://172.232.119.157:5173/"
 # user-provided application name for reference
 kite_app_name: "backtester"
 # default investment amount by confidence score 1-10


### PR DESCRIPTION
## Summary
- default frontend URL to `http://172.232.119.157:5173/`
- document new address for React app login in README
- update config class to insert and return new default

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q test` *(fails: Non-resolvable import POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6842bf2f5e4483239a248e6128bad7f5