### PR TITLE
Enable debug logging

### DIFF
--- a/backend/src/main/java/com/backtester/RedisStore.java
+++ b/backend/src/main/java/com/backtester/RedisStore.java
@@ -11,7 +11,9 @@ public class RedisStore {
 
     public static String get(String key) {
         try {
-            return jedis.get(key);
+            String val = jedis.get(key);
+            logger.debug("Redis GET {} -> {}", key, val);
+            return val;
         } catch (JedisConnectionException e) {
             logger.error("Redis not available", e);
             return null;
@@ -21,6 +23,7 @@ public class RedisStore {
     public static void set(String key, String value) {
         try {
             jedis.set(key, value);
+            logger.debug("Redis SET {}", key);
         } catch (JedisConnectionException e) {
             logger.error("Redis not available", e);
         }

--- a/backend/src/main/java/com/backtester/controller/AuthController.java
+++ b/backend/src/main/java/com/backtester/controller/AuthController.java
@@ -26,6 +26,7 @@ public class AuthController {
     private static Process rssProcess;
     @GetMapping("/login")
     public void login(HttpServletResponse response) throws IOException {
+        logger.debug("Initiating Zerodha login flow");
         String apiKey = Config.get("kite_api_key");
         String redirect = Config.get("kite_redirect_uri");
         if (apiKey == null || apiKey.isEmpty() || redirect == null || redirect.isEmpty()) {
@@ -47,6 +48,7 @@ public class AuthController {
     @GetMapping("/callback")
     public void callback(@RequestParam("request_token") String token,
                          HttpServletResponse response) throws IOException {
+        logger.debug("Received OAuth callback with token {}", token);
         String apiKey = Config.get("kite_api_key");
         String secret = Config.get("kite_api_secret");
         String checksum = sha256(apiKey + token + secret);
@@ -68,6 +70,7 @@ public class AuthController {
             ObjectMapper mapper = new ObjectMapper();
             JsonNode root = mapper.readTree(conn.getInputStream());
             String access = root.path("data").path("access_token").asText();
+            logger.debug("Received access token {}", access);
             RedisStore.set("kite_access_token", access);
             message = "Access token captured successfully";
             if (rssProcess == null || !rssProcess.isAlive()) {

--- a/backend/src/main/java/com/backtester/controller/BacktestController.java
+++ b/backend/src/main/java/com/backtester/controller/BacktestController.java
@@ -36,6 +36,8 @@ public class BacktestController {
                                  @RequestParam(required = false, name = "to") String to,
                                  @RequestParam(required = false, name = "end") String end,
                                  @RequestParam double capital) {
+        logger.debug("Backtest request: strategy={} symbol={} period={} from={} to={} capital={}",
+                strategy, symbol, period, from != null ? from : start, to != null ? to : end, capital);
         if (from == null) from = start;
         if (to == null) to = end;
         if (from == null || to == null) {

--- a/backend/src/main/java/com/backtester/controller/FeedController.java
+++ b/backend/src/main/java/com/backtester/controller/FeedController.java
@@ -22,8 +22,10 @@ public class FeedController {
 
     @GetMapping
     public ResponseEntity<?> list() {
+        logger.debug("Fetching RSS feed entries from redis");
         try {
             Set<String> keys = jedis.keys("headline:*");
+            logger.debug("Found {} entries in redis", keys.size());
             List<Map<String, Object>> out = new ArrayList<>();
             for (String k : keys) {
                 try {

--- a/backend/src/main/java/com/backtester/service/HistoryService.java
+++ b/backend/src/main/java/com/backtester/service/HistoryService.java
@@ -1,6 +1,8 @@
 package com.backtester.service;
 
 import com.backtester.strategy.BacktestResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.LinkedList;
@@ -9,12 +11,15 @@ import java.util.List;
 @Service
 public class HistoryService {
     private final List<String> history = new LinkedList<>();
+    private static final Logger logger = LoggerFactory.getLogger(HistoryService.class);
 
     public void add(String entry) {
+        logger.debug("Adding history entry: {}", entry);
         history.add(0, entry);
     }
 
     public List<String> getHistory() {
+        logger.debug("Returning {} history entries", history.size());
         return history;
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+logging.level.root=DEBUG


### PR DESCRIPTION
## Summary
- set root log level to DEBUG
- log cache hits and API requests in `QuoteService`
- log incoming parameters in `BacktestController`
- add debug logs around Redis access and feed retrieval
- log access token after OAuth callback
- make `rss_monitor.py` use debug logging

## Testing
- `python3 -m py_compile rss_monitor.py`
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cb1080b08323a1fe27fad9f8a73a