### PR TITLE
Fix Kite API auth headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ open `http://172.232.119.157:5173/login` and click **Login with Zerodha** to beg
 OAuth flow. On success the backend stores the returned access token in memory
 for subsequent API calls.
 
+All requests to the Kite API must include the access token in an `Authorization`
+header of the form `token <api_key>:<access_token>`. Do not pass the token in
+the query string.
+
 Set `frontend_url` in `config.yaml` to the address where the React app is served
 (default `http://172.232.119.157:5173/`). The backend redirects here after successful
 authentication.

--- a/backend/src/main/java/com/backtester/service/QuoteService.java
+++ b/backend/src/main/java/com/backtester/service/QuoteService.java
@@ -102,14 +102,18 @@ public class QuoteService {
     private List<Double> fetchFromKite(String symbol, String period, String from, String to) {
         String apiKey = Config.get("kite_api_key");
         String accessToken = RedisStore.get("kite_access_token");
+        if (accessToken == null || accessToken.isEmpty()) {
+            return new ArrayList<>();
+        }
         String url = String.format(
-                "https://api.kite.trade/instruments/historical/%s/%s?from=%s&to=%s&api_key=%s&access_token=%s",
-                symbol, period, from, to, apiKey, accessToken);
+                "https://api.kite.trade/instruments/historical/%s/%s?from=%s&to=%s",
+                symbol, period, from, to);
         try {
             logger.debug("Requesting data from KITE: {}", url);
             URL u = new URL(url);
             HttpURLConnection conn = (HttpURLConnection) u.openConnection();
             conn.setRequestProperty("X-Kite-Version", "3");
+            conn.setRequestProperty("Authorization", String.format("token %s:%s", apiKey, accessToken));
             conn.setRequestMethod("GET");
             if (conn.getResponseCode() != 200) {
                 return new ArrayList<>();


### PR DESCRIPTION
## Summary
- fetch Kite historical data using header auth
- document using Kite Authorization header

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fbe7ee0c8323bff962e15eda9387