### PR TITLE
Fix token parsing and update intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project provides a Java Spring Boot backend and a React frontend for runnin
 
 ## Backend
 
-The backend is located in the `backend` directory. It exposes a REST endpoint `/api/backtest` that accepts strategy name, symbol, candle period (e.g. `1d`, `1m`, `5m`, `30m`, `1w`), date range and initial capital. Supported strategies now cover a wide selection including:
+The backend is located in the `backend` directory. It exposes a REST endpoint `/api/backtest` that accepts strategy name, symbol, candle period and date range along with the initial capital. Candle periods correspond to the Zerodha KITE interval names such as `minute`, `day`, `3minute`, `5minute`, `10minute`, `15minute`, `30minute` and `60minute`. Supported strategies now cover a wide selection including:
 
 * `RSI`, `MACD`, `BollingerBands`, `Supertrend`
 * `RSI_SMA`, `MACD_CROSS`, `Bollinger_Reversal`, `Golden_Cross`

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -42,13 +42,13 @@ function ConfidenceTable() {
 }
 
 export default function Dashboard() {
-  const [form, setForm] = useState({ strategy: 'RSI', symbol: '', period: '1d', start: '', end: '', capital: 100000 })
+  const [form, setForm] = useState({ strategy: 'RSI', symbol: '', period: 'day', start: '', end: '', capital: 100000 })
   const [errors, setErrors] = useState({})
   const [result, setResult] = useState(null)
   const [instruments, setInstruments] = useState([])
 
   const strategies = ['RSI', 'MACD', 'BollingerBands', 'Supertrend']
-  const periods = ['1d', '5m']
+  const periods = ['minute', 'day', '3minute', '5minute', '10minute', '15minute', '30minute', '60minute']
 
   useEffect(() => {
     const load = async () => {

--- a/rss_monitor.py
+++ b/rss_monitor.py
@@ -56,6 +56,12 @@ def process_entry(entry):
     text = resp.choices[0].message.content.strip()
     try:
         data = json.loads(text)
+        tokens = data.get("tokens")
+        if isinstance(tokens, str):
+            tokens = [t.strip().strip("'\"") for t in tokens.split(',') if t.strip()]
+        elif isinstance(tokens, list):
+            tokens = [str(t).strip("'\"") for t in tokens]
+        data["tokens"] = tokens
     except json.JSONDecodeError:
         data = {"error": "Failed to parse", "raw": text}
     stored = {


### PR DESCRIPTION
## Summary
- document Zerodha interval names
- list full Kite intervals in the frontend
- sanitize tokens returned by rss_monitor

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ff73a2b4832393d320d731734e0b