### PR TITLE
Add RSS fetching service in Java

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -36,6 +36,11 @@
             <version>2.13.4</version>
         </dependency>
         <dependency>
+            <groupId>com.rometools</groupId>
+            <artifactId>rome</artifactId>
+            <version>1.18.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/backend/src/main/java/com/backtester/service/RssService.java
+++ b/backend/src/main/java/com/backtester/service/RssService.java
@@ -1,0 +1,39 @@
+package com.backtester.service;
+
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.XmlReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+@Service
+public class RssService {
+    private static final Logger logger = LoggerFactory.getLogger(RssService.class);
+
+    public SyndFeed fetchFeed(String rssUrl) {
+        try {
+            logger.debug("Fetching RSS feed from {}", rssUrl);
+            URL url = new URL(rssUrl);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(10000);
+            conn.setReadTimeout(10000);
+
+            try (XmlReader reader = new XmlReader(conn)) {
+                SyndFeedInput input = new SyndFeedInput();
+                SyndFeed feed = input.build(reader);
+                logger.debug("Parsed {} entries", feed.getEntries().size());
+                return feed;
+            }
+        } catch (Exception e) {
+            logger.error("Failed to fetch or parse RSS feed", e);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `rome` dependency to parse RSS feeds
- implement `RssService` using `rome` to fetch feeds with a custom User-Agent
- expose new `/api/feed/remote` endpoint in `FeedController`

## Testing
- `mvn -q -DskipTests package` *(fails: transfer failed, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684305cedb088323b2ac39f938aa8cef