### PR TITLE
Fix FeedController compilation with Java 8

### DIFF
--- a/backend/src/main/java/com/backtester/controller/FeedController.java
+++ b/backend/src/main/java/com/backtester/controller/FeedController.java
@@ -5,6 +5,7 @@ import com.backtester.service.RssService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.feed.synd.SyndEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -134,7 +135,7 @@ public class FeedController {
                     .body(Map.of("error", "Failed to fetch feed"));
         }
         int processed = 0;
-        for (var entry : feed.getEntries()) {
+        for (SyndEntry entry : feed.getEntries()) {
             try {
                 String id = sha1(entry.getLink());
                 String key = "headline:" + id;


### PR DESCRIPTION
## Summary
- add missing import for `SyndEntry`
- replace `var` with explicit `SyndEntry` type to build on Java 8

## Testing
- `mvn -q test` *(fails: Could not download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68430fa90ec883239e60364902695c4f