### PR TITLE
Fix sentiment page navigation

### DIFF
--- a/backend/src/main/java/com/backtester/BacktesterApplication.java
+++ b/backend/src/main/java/com/backtester/BacktesterApplication.java
@@ -2,7 +2,9 @@ package com.backtester;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class BacktesterApplication {
     public static void main(String[] args) {

--- a/backend/src/main/java/com/backtester/controller/FeedController.java
+++ b/backend/src/main/java/com/backtester/controller/FeedController.java
@@ -1,11 +1,7 @@
 package com.backtester.controller;
 
-import com.backtester.Config;
-import com.backtester.service.RssService;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rometools.rome.feed.synd.SyndFeed;
-import com.rometools.rome.feed.synd.SyndEntry;
+import com.backtester.service.FeedService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,11 +11,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import redis.clients.jedis.Jedis;
-
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.util.*;
 
 @RestController
@@ -29,41 +20,14 @@ public class FeedController {
     private final Jedis jedis = new Jedis("redis://localhost:6379");
     private final ObjectMapper mapper = new ObjectMapper();
     private static final Logger logger = LoggerFactory.getLogger(FeedController.class);
-    private static final String PROMPT = "Analyze this news item and respond with JSON. " +
-            "Fields: tokens (list of affected NSE symbols), action (Buy or Sell), " +
-            "confidence (0-10), term ('short' or 'long' for expected profit horizon), " +
-            "reason. Use concise JSON only. News: '%s - %s'.";
 
     @Autowired
-    private RssService rssService;
-
-    private static final List<String> RSS_FEEDS = List.of(
-            // 📈 Business Standard RSS Feeds
-            "https://www.business-standard.com/rss/markets-106.rss",
-            "https://www.business-standard.com/rss/companies-102.rss",
-            "https://www.business-standard.com/rss/economy-101.rss",
-
-            // 📈 Livemint RSS Feed
-            "https://www.livemint.com/rss/markets",
-
-            // 📈 Moneycontrol RSS Feeds (may be unreliable)
-            "https://www.moneycontrol.com/rss/markets.xml",
-            "https://www.moneycontrol.com/rss/MCtopnews.xml",
-            "https://www.moneycontrol.com/rss/mfnews.xml",
-            "https://www.moneycontrol.com/rss/iponews.xml",
-
-            // 📈 Economic Times RSS Feeds
-            "https://economictimes.indiatimes.com/rssfeedsdefault.cms",
-            "https://economictimes.indiatimes.com/markets/rssfeeds/1977021501.cms",
-            "https://economictimes.indiatimes.com/markets/sensex/rssfeeds/2146841734.cms",
-            "https://economictimes.indiatimes.com/markets/ipos/rssfeeds/70323525.cms"
-    );
+    private FeedService feedService;
 
     @GetMapping
     public ResponseEntity<?> list() {
-        // refresh the feed from remote sources before listing
         try {
-            remote();
+            feedService.refreshFeeds();
         } catch (Exception e) {
             logger.warn("Failed to refresh feed", e);
         }
@@ -108,91 +72,11 @@ public class FeedController {
         }
     }
 
-    private Map<String, Object> analyze(String title, String description) {
-        String prompt = String.format(PROMPT, title, description == null ? "" : description);
-        try {
-            URL url = new URL("https://api.groq.com/openai/v1/chat/completions");
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestMethod("POST");
-            conn.setRequestProperty("Content-Type", "application/json");
-            conn.setRequestProperty("Authorization", "Bearer " + Config.get("groq_api_key"));
-            conn.setConnectTimeout(10000);
-            conn.setReadTimeout(10000);
-            conn.setDoOutput(true);
-            String payload = mapper.writeValueAsString(Map.of(
-                    "model", "gpt-4",
-                    "messages", List.of(Map.of("role", "user", "content", prompt))
-            ));
-            conn.getOutputStream().write(payload.getBytes(StandardCharsets.UTF_8));
-            JsonNode root = mapper.readTree(conn.getInputStream());
-            String text = root.path("choices").get(0).path("message").path("content").asText().trim();
-            Map<String, Object> data;
-            try {
-                data = mapper.readValue(text, Map.class);
-                Object tokens = data.get("tokens");
-                if (tokens instanceof String) {
-                    String[] parts = ((String) tokens).split(",");
-                    List<String> list = new ArrayList<>();
-                    for (String p : parts) {
-                        String t = p.trim().replaceAll("^['\"]|['\"]$", "");
-                        if (!t.isEmpty()) list.add(t);
-                    }
-                    data.put("tokens", list);
-                }
-            } catch (Exception e) {
-                data = new HashMap<>();
-                data.put("error", "Failed to parse");
-                data.put("raw", text);
-            }
-            return data;
-        } catch (Exception e) {
-            logger.error("Failed to analyze feed", e);
-            Map<String, Object> err = new HashMap<>();
-            err.put("error", "Request failed");
-            err.put("message", e.getMessage());
-            return err;
-        }
-    }
 
     @GetMapping("/remote")
     public ResponseEntity<?> remote() {
-        int processed = 0;
-        for (String url : RSS_FEEDS) {
-            SyndFeed feed = rssService.fetchFeed(url);
-            if (feed == null) {
-                continue;
-            }
-            for (SyndEntry entry : feed.getEntries()) {
-                try {
-                    String id = sha1(entry.getLink());
-                    String key = "headline:" + id;
-                    if (jedis.exists(key)) {
-                        continue;
-                    }
-                    Map<String, Object> stored = new HashMap<>();
-                    stored.put("title", entry.getTitle());
-                    stored.put("link", entry.getLink());
-                    Map<String, Object> analysis = analyze(entry.getTitle(),
-                            entry.getDescription() != null ? entry.getDescription().getValue() : "");
-                    stored.put("analysis", analysis);
-                    stored.put("timestamp", System.currentTimeMillis() / 1000);
-                    stored.put("close", Math.round((90 + Math.random() * 20) * 100.0) / 100.0);
-                    jedis.set(key, mapper.writeValueAsString(stored));
-                    processed++;
-                } catch (Exception e) {
-                    logger.warn("Failed to process entry {}", entry.getLink(), e);
-                }
-            }
-        }
-        return ResponseEntity.ok(Map.of("processed", processed));
-    }
-
-    private String sha1(String input) throws Exception {
-        MessageDigest md = MessageDigest.getInstance("SHA-1");
-        byte[] bytes = md.digest(input.getBytes(StandardCharsets.UTF_8));
-        StringBuilder sb = new StringBuilder();
-        for (byte b : bytes) sb.append(String.format("%02x", b));
-        return sb.toString();
+        Map<String, Object> res = feedService.refreshFeeds();
+        return ResponseEntity.ok(res);
     }
 }
 

--- a/backend/src/main/java/com/backtester/service/FeedService.java
+++ b/backend/src/main/java/com/backtester/service/FeedService.java
@@ -1,0 +1,150 @@
+package com.backtester.service;
+
+import com.backtester.Config;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import redis.clients.jedis.Jedis;
+
+import java.io.FileWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.*;
+
+@Service
+public class FeedService {
+    private static final Logger logger = LoggerFactory.getLogger(FeedService.class);
+    private static final String LAST_FETCH_KEY = "rss:last_fetch";
+    private static final long MIN_INTERVAL = 300; // 5 minutes
+    private final Jedis jedis = new Jedis("redis://localhost:6379");
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private static final List<String> RSS_FEEDS = Arrays.asList(
+            "https://www.business-standard.com/rss/markets-106.rss",
+            "https://www.business-standard.com/rss/companies-102.rss",
+            "https://www.business-standard.com/rss/economy-101.rss",
+            "https://www.livemint.com/rss/markets",
+            "https://www.moneycontrol.com/rss/markets.xml",
+            "https://www.moneycontrol.com/rss/MCtopnews.xml",
+            "https://www.moneycontrol.com/rss/mfnews.xml",
+            "https://www.moneycontrol.com/rss/iponews.xml",
+            "https://economictimes.indiatimes.com/rssfeedsdefault.cms",
+            "https://economictimes.indiatimes.com/markets/rssfeeds/1977021501.cms",
+            "https://economictimes.indiatimes.com/markets/sensex/rssfeeds/2146841734.cms",
+            "https://economictimes.indiatimes.com/markets/ipos/rssfeeds/70323525.cms"
+    );
+
+    @Autowired
+    private RssService rssService;
+
+    public synchronized Map<String, Object> refreshFeeds() {
+        long now = System.currentTimeMillis() / 1000;
+        try {
+            String ts = jedis.get(LAST_FETCH_KEY);
+            if (ts != null && now - Long.parseLong(ts) < MIN_INTERVAL) {
+                logger.debug("RSS fetch skipped; last fetch {} seconds ago", now - Long.parseLong(ts));
+                Map<String, Object> res = new HashMap<>();
+                res.put("skipped", true);
+                return res;
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to check last fetch", e);
+        }
+        int processed = 0;
+        for (String url : RSS_FEEDS) {
+            SyndFeed feed = rssService.fetchFeed(url);
+            if (feed == null) continue;
+            for (SyndEntry entry : feed.getEntries()) {
+                try {
+                    String id = sha1(entry.getLink());
+                    String key = "headline:" + id;
+                    if (jedis.exists(key)) {
+                        continue;
+                    }
+                    Map<String, Object> stored = new HashMap<>();
+                    stored.put("title", entry.getTitle());
+                    stored.put("link", entry.getLink());
+                    Map<String, Object> analysis = analyze(entry.getTitle(), entry.getDescription() != null ? entry.getDescription().getValue() : "");
+                    stored.put("analysis", analysis);
+                    stored.put("timestamp", now);
+                    stored.put("close", Math.round((90 + Math.random() * 20) * 100.0) / 100.0);
+                    jedis.set(key, mapper.writeValueAsString(stored));
+                    try (FileWriter fw = new FileWriter("feed.jsonl", true)) {
+                        fw.write(mapper.writeValueAsString(stored));
+                        fw.write("\n");
+                    } catch (Exception e) {
+                        logger.warn("Failed to persist feed entry", e);
+                    }
+                    processed++;
+                } catch (Exception e) {
+                    logger.warn("Failed to process entry {}", entry.getLink(), e);
+                }
+            }
+        }
+        jedis.set(LAST_FETCH_KEY, String.valueOf(now));
+        return Collections.singletonMap("processed", processed);
+    }
+
+    @Scheduled(fixedDelay = MIN_INTERVAL * 1000)
+    public void scheduledFetch() {
+        try {
+            refreshFeeds();
+        } catch (Exception e) {
+            logger.warn("Scheduled fetch failed", e);
+        }
+    }
+
+    private Map<String, Object> analyze(String title, String description) throws Exception {
+        String prompt = String.format(
+                "Analyze this news item and respond with JSON. Fields: tokens (list of affected NSE symbols), action (Buy or Sell), confidence (0-10), term ('short' or 'long' for expected profit horizon), reason. Use concise JSON only. News: '%s - %s'.",
+                title, description == null ? "" : description);
+        URL url = new URL("https://api.groq.com/openai/v1/chat/completions");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setRequestProperty("Authorization", "Bearer " + Config.get("groq_api_key"));
+        conn.setConnectTimeout(10000);
+        conn.setReadTimeout(10000);
+        conn.setDoOutput(true);
+        String payload = mapper.writeValueAsString(Collections.singletonMap("model", "gpt-4"));
+        String body = String.format("{\"model\":\"gpt-4\",\"messages\":[{\"role\":\"user\",\"content\":%s}]}", mapper.writeValueAsString(prompt));
+        conn.getOutputStream().write(body.getBytes(StandardCharsets.UTF_8));
+        JsonNode root = mapper.readTree(conn.getInputStream());
+        String text = root.path("choices").get(0).path("message").path("content").asText().trim();
+        try {
+            Map<String, Object> data = mapper.readValue(text, Map.class);
+            Object tokens = data.get("tokens");
+            if (tokens instanceof String) {
+                String[] parts = ((String) tokens).split(",");
+                List<String> list = new ArrayList<>();
+                for (String p : parts) {
+                    String t = p.trim().replaceAll("^['\"]|['\"]$", "");
+                    if (!t.isEmpty()) list.add(t);
+                }
+                data.put("tokens", list);
+            }
+            return data;
+        } catch (Exception e) {
+            Map<String, Object> err = new HashMap<>();
+            err.put("error", "Failed to parse");
+            err.put("raw", text);
+            return err;
+        }
+    }
+
+    private String sha1(String input) throws Exception {
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        byte[] bytes = md.digest(input.getBytes(StandardCharsets.UTF_8));
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) sb.append(String.format("%02x", b));
+        return sb.toString();
+    }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,10 +2,12 @@ import React, { useState, useEffect } from 'react'
 import Navbar from './components/Navbar.jsx'
 import Sidebar from './components/Sidebar.jsx'
 import Dashboard from './components/Dashboard.jsx'
+import SentimentTable from './components/SentimentTable.jsx'
 
 export default function App() {
   const [dark, setDark] = useState(false)
   const [sidebar, setSidebar] = useState(false)
+  const [page, setPage] = useState('backtest')
   useEffect(() => {
     document.documentElement.classList.toggle('dark', dark)
   }, [dark])
@@ -28,13 +30,19 @@ export default function App() {
     }
     verify()
   }, [])
+  const navigate = p => {
+    setPage(p)
+    setSidebar(false)
+  }
+
   return (
     <div className="flex h-screen">
-      <Sidebar open={sidebar} onClose={() => setSidebar(false)} />
+      <Sidebar open={sidebar} onClose={() => setSidebar(false)} onNav={navigate} />
       <div className="flex flex-col flex-1">
         <Navbar dark={dark} onToggle={() => setDark(!dark)} onMenu={() => setSidebar(true)} />
         <main className="flex-1 p-4 overflow-y-auto bg-gray-100 dark:bg-gray-900">
-          <Dashboard />
+          {page === 'backtest' && <Dashboard />}
+          {page === 'sentiment' && <SentimentTable />}
         </main>
       </div>
     </div>

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react'
 import ResultCard from './ResultCard.jsx'
-import SentimentTable from './SentimentTable.jsx'
 
 function ConfidenceTable() {
   const stored = JSON.parse(localStorage.getItem('confidence_investment') || '{}')
@@ -132,7 +131,6 @@ export default function Dashboard() {
       </form>
       <ResultCard result={result} />
       <ConfidenceTable />
-      <SentimentTable />
     </div>
   )
 }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-export default function Sidebar({ open, onClose }) {
+export default function Sidebar({ open, onClose, onNav }) {
   return (
     <div className={`fixed inset-y-0 left-0 z-20 transform bg-gray-200 dark:bg-gray-800 w-48 p-4 space-y-4 md:static md:translate-x-0 transition-transform ${open ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}> 
       <button className="md:hidden mb-4" onClick={onClose} aria-label="Close menu">✕</button>
       <nav className="space-y-2">
-        <a href="#" className="flex items-center space-x-2 hover:text-blue-600"><span>📈</span><span>Backtest</span></a>
-        <a href="#" className="flex items-center space-x-2 hover:text-blue-600"><span>💬</span><span>Sentiment</span></a>
+        <a href="#" onClick={e => { e.preventDefault(); onNav('backtest'); }} className="flex items-center space-x-2 hover:text-blue-600"><span>📈</span><span>Backtest</span></a>
+        <a href="#" onClick={e => { e.preventDefault(); onNav('sentiment'); }} className="flex items-center space-x-2 hover:text-blue-600"><span>💬</span><span>Sentiment</span></a>
         <a href="#" className="flex items-center space-x-2 hover:text-blue-600"><span>📜</span><span>History</span></a>
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- make Sentiment page accessible from sidebar
- move SentimentTable out of Dashboard and render per page
- refresh RSS feeds via scheduled FeedService with five minute cadence
- skip fetching if last fetch was less than 5 minutes ago
- expose `/api/feed/remote` endpoint using new FeedService

## Testing
- `npm install`
- `npm run build`
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431518af648323b085e4cbadc3d10b