### PR TITLE
Show token details per RSS feed

### DIFF
--- a/backend/src/main/java/com/backtester/service/QuoteService.java
+++ b/backend/src/main/java/com/backtester/service/QuoteService.java
@@ -243,7 +243,7 @@ public class QuoteService {
         }
     }
 
-    private String resolveToken(String symbol) {
+    public String resolveToken(String symbol) {
         if (symbol.matches("\\d+")) return symbol;
         for (Map<String, String> m : getInstruments()) {
             String ts = m.get("tradingsymbol");

--- a/frontend/src/components/SentimentTable.jsx
+++ b/frontend/src/components/SentimentTable.jsx
@@ -24,9 +24,9 @@ export default function SentimentTable() {
     setLoading(false)
   }
 
-  const execute = (it) => {
-    const t = { action: it.analysis?.action || 'Buy', amount: 1, price: it.current }
-    const next = { ...trades, [it.id]: t }
+  const execute = (key, action, price) => {
+    const t = { action, amount: 1, price }
+    const next = { ...trades, [key]: t }
     setTrades(next)
     localStorage.setItem('trades', JSON.stringify(next))
   }
@@ -54,35 +54,61 @@ export default function SentimentTable() {
             <tr>
               <th className="px-2">News</th>
               <th className="px-2">Analysis</th>
+              <th className="px-2">Stock</th>
+              <th className="px-2">Publish</th>
               <th className="px-2">Last</th>
-              <th className="px-2">Current</th>
+              <th className="px-2">Conf.</th>
               <th className="px-2">Action</th>
-              <th className="px-2">Related</th>
               <th className="px-2">Trades</th>
             </tr>
           </thead>
           <tbody>
             {items.map(it => (
-              <tr key={it.id} id={it.id} className="odd:bg-gray-50 dark:odd:bg-gray-700">
-                <td className="p-2">
-                  <a href={it.link} target="_blank" rel="noopener noreferrer" className="underline">
-                    {it.title}
-                  </a>
-                  <div className="text-xs opacity-70">{new Date(it.timestamp * 1000).toLocaleString()}</div>
-                </td>
-                <td className="p-2 text-sm">{it.analysis?.reason}</td>
-                <td className="p-2 text-right">{it.close?.toFixed(2)}</td>
-                <td className="p-2 text-right">{it.current?.toFixed(2)}</td>
-                <td className="p-2 text-center">
-                  <button onClick={() => execute(it)} className="px-2 py-1 bg-green-600 text-white rounded">
-                    {it.analysis?.action || 'Buy'}
-                  </button>
-                </td>
-                <td className="p-2">{relatedLinks(it)}</td>
-                <td className="p-2 text-sm">
-                  {trades[it.id] ? `${trades[it.id].action}@${trades[it.id].price} x${trades[it.id].amount}` : 'No trades taken'}
-                </td>
-              </tr>
+              <React.Fragment key={it.id}>
+                <tr id={it.id} className="odd:bg-gray-50 dark:odd:bg-gray-700">
+                  <td rowSpan={Math.max(it.stocks?.length || 1, 1)} className="p-2">
+                    <a href={it.link} target="_blank" rel="noopener noreferrer" className="underline">
+                      {it.title}
+                    </a>
+                    <div className="text-xs opacity-70">{new Date(it.timestamp * 1000).toLocaleString()}</div>
+                  </td>
+                  <td rowSpan={Math.max(it.stocks?.length || 1, 1)} className="p-2 text-sm">{it.analysis?.reason}</td>
+                  {it.stocks && it.stocks.length ? (
+                    <>
+                      <td className="p-2">{it.stocks[0].symbol} ({it.stocks[0].token})</td>
+                      <td className="p-2 text-right">{it.stocks[0].close?.toFixed(2)}</td>
+                      <td className="p-2 text-right">{it.stocks[0].current?.toFixed(2)}</td>
+                      <td className="p-2 text-center">{it.stocks[0].confidence?.toFixed(1)}</td>
+                      <td className="p-2 text-center">
+                        <button onClick={() => execute(`${it.id}-${it.stocks[0].symbol}`, it.stocks[0].action || 'Buy', it.stocks[0].current)} className="px-2 py-1 bg-green-600 text-white rounded">
+                          {it.stocks[0].action || 'Buy'}
+                        </button>
+                      </td>
+                      <td rowSpan={Math.max(it.stocks?.length || 1, 1)} className="p-2 text-sm">
+                        {Object.entries(trades).filter(([k]) => k.startsWith(it.id + '-')).map(([k,v]) => `${k.split('-')[1]}:${v.action}@${v.price}`).join('; ') || 'No trades taken'}
+                      </td>
+                    </>
+                  ) : (
+                    <>
+                      <td className="p-2" colSpan={5}>No stocks</td>
+                      <td rowSpan={1} className="p-2 text-sm">No trades taken</td>
+                    </>
+                  )}
+                </tr>
+                {it.stocks && it.stocks.slice(1).map(s => (
+                  <tr key={`${it.id}-${s.symbol}`} className="odd:bg-gray-50 dark:odd:bg-gray-700">
+                    <td className="p-2">{s.symbol} ({s.token})</td>
+                    <td className="p-2 text-right">{s.close?.toFixed(2)}</td>
+                    <td className="p-2 text-right">{s.current?.toFixed(2)}</td>
+                    <td className="p-2 text-center">{s.confidence?.toFixed(1)}</td>
+                    <td className="p-2 text-center">
+                      <button onClick={() => execute(`${it.id}-${s.symbol}`, s.action || 'Buy', s.current)} className="px-2 py-1 bg-green-600 text-white rounded">
+                        {s.action || 'Buy'}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </React.Fragment>
             ))}
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
- expose `resolveToken` from `QuoteService`
- include per-stock details in `FeedController`
- display subrows with token info in `SentimentTable`

## Testing
- `npm install`
- `npm run build`
- ⚠️ `mvn` command failed: `mvn: command not found`

------
https://chatgpt.com/codex/tasks/task_e_68431a062b68832397a08ba61e3a8dfb