### PR TITLE
Add kite order placement support

### DIFF
--- a/backend/src/main/java/com/backtester/controller/OrderController.java
+++ b/backend/src/main/java/com/backtester/controller/OrderController.java
@@ -1,0 +1,33 @@
+package com.backtester.controller;
+
+import com.backtester.service.OrderService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/order")
+public class OrderController {
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @GetMapping("/funds")
+    public Map<String, Double> funds() {
+        double f = orderService.getFunds();
+        return Map.of("funds", f);
+    }
+
+    @PostMapping
+    public ResponseEntity<?> place(@RequestBody Map<String, Object> payload) {
+        String symbol = (String) payload.get("symbol");
+        String exchange = (String) payload.getOrDefault("exchange", "NSE");
+        String action = (String) payload.getOrDefault("action", "BUY");
+        int qty = ((Number) payload.getOrDefault("quantity", 0)).intValue();
+        double price = ((Number) payload.getOrDefault("price", 0)).doubleValue();
+        return ResponseEntity.ok(orderService.placeOrder(symbol, exchange, action, qty, price));
+    }
+}

--- a/backend/src/main/java/com/backtester/service/OrderService.java
+++ b/backend/src/main/java/com/backtester/service/OrderService.java
@@ -1,0 +1,74 @@
+package com.backtester.service;
+
+import com.backtester.Config;
+import com.backtester.RedisStore;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class OrderService {
+    private static final Logger logger = LoggerFactory.getLogger(OrderService.class);
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private HttpURLConnection makeConn(String endpoint, String method) throws IOException {
+        String apiKey = Config.get("kite_api_key");
+        String access = RedisStore.get("kite_access_token");
+        URL url = new URL(endpoint);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod(method);
+        conn.setRequestProperty("X-Kite-Version", "3");
+        conn.setRequestProperty("Authorization", String.format("token %s:%s", apiKey, access));
+        return conn;
+    }
+
+    public double getFunds() {
+        try {
+            HttpURLConnection conn = makeConn("https://api.kite.trade/user/margins", "GET");
+            if (conn.getResponseCode() != 200) {
+                logger.warn("Funds request failed with code {}", conn.getResponseCode());
+                return 0.0;
+            }
+            JsonNode root = mapper.readTree(conn.getInputStream());
+            return root.path("data").path("equity").path("available").path("cash").asDouble();
+        } catch (Exception e) {
+            logger.error("Failed to fetch funds", e);
+            return 0.0;
+        }
+    }
+
+    public Map<String, Object> placeOrder(String tradingsymbol, String exchange, String action,
+                                          int quantity, double price) {
+        try {
+            HttpURLConnection conn = makeConn("https://api.kite.trade/orders/regular", "POST");
+            conn.setDoOutput(true);
+            String body = String.format(
+                    "tradingsymbol=%s&exchange=%s&transaction_type=%s&order_type=LIMIT&quantity=%d&price=%.2f&product=MIS&validity=DAY",
+                    tradingsymbol, exchange, action.toUpperCase(), quantity, price);
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body.getBytes());
+            }
+            if (conn.getResponseCode() != 200) {
+                logger.warn("Order failed with code {}", conn.getResponseCode());
+                return Map.of("error", "Order rejected", "code", conn.getResponseCode());
+            }
+            JsonNode root = mapper.readTree(conn.getInputStream());
+            Map<String, Object> res = new HashMap<>();
+            res.put("status", root.path("status").asText());
+            res.put("order_id", root.path("data").path("order_id").asText());
+            return res;
+        } catch (Exception e) {
+            logger.error("Failed to place order", e);
+            return Map.of("error", e.getMessage());
+        }
+    }
+}

--- a/frontend/src/components/OrderDialog.jsx
+++ b/frontend/src/components/OrderDialog.jsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react'
+
+export default function OrderDialog({ open, onClose, item, onPlaced }) {
+  const [funds, setFunds] = useState(0)
+  const [quantity, setQuantity] = useState(1)
+  const [price, setPrice] = useState(item?.current || 0)
+
+  useEffect(() => {
+    if (!open) return
+    fetch('/api/order/funds')
+      .then(res => res.json())
+      .then(d => setFunds(d.funds || 0))
+  }, [open])
+
+  useEffect(() => {
+    if (item) {
+      setPrice(item.current || 0)
+      setQuantity(1)
+    }
+  }, [item])
+
+  const onQtyChange = e => {
+    const q = parseInt(e.target.value || '0', 10)
+    setQuantity(q)
+    if (q > 0) setPrice((funds / q).toFixed(2))
+  }
+
+  const onPriceChange = e => {
+    const p = parseFloat(e.target.value || '0')
+    setPrice(p)
+    if (p > 0) setQuantity(Math.floor(funds / p))
+  }
+
+  const place = async () => {
+    await fetch('/api/order', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        symbol: item.analysis?.tokens?.[0] || item.symbol,
+        action: item.analysis?.action || 'BUY',
+        quantity: quantity,
+        price: price,
+      })
+    })
+    if (onPlaced) onPlaced({ action: item.analysis?.action || 'Buy', amount: quantity, price })
+    onClose()
+  }
+
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-30">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow w-72 space-y-4">
+        <h3 className="font-semibold text-lg">Place Order</h3>
+        <div>Available: {funds.toFixed(2)}</div>
+        <div>
+          <label className="block text-sm">Quantity</label>
+          <input type="number" value={quantity} onChange={onQtyChange} className="mt-1 w-full p-2 rounded border dark:bg-gray-700" />
+        </div>
+        <div>
+          <label className="block text-sm">Price</label>
+          <input type="number" value={price} onChange={onPriceChange} className="mt-1 w-full p-2 rounded border dark:bg-gray-700" />
+        </div>
+        <div className="flex justify-end space-x-2">
+          <button onClick={onClose} className="px-3 py-1 bg-gray-300 rounded">Cancel</button>
+          <button onClick={place} className="px-3 py-1 bg-blue-600 text-white rounded">Place Order</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/SentimentTable.jsx
+++ b/frontend/src/components/SentimentTable.jsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react'
+import OrderDialog from './OrderDialog.jsx'
 
 export default function SentimentTable() {
   const [items, setItems] = useState([])
   const [trades, setTrades] = useState(() => JSON.parse(localStorage.getItem('trades') || '{}'))
   const [loading, setLoading] = useState(false)
+  const [dialogItem, setDialogItem] = useState(null)
 
   useEffect(() => {
     const load = async () => {
@@ -25,10 +27,7 @@ export default function SentimentTable() {
   }
 
   const execute = (it) => {
-    const t = { action: it.analysis?.action || 'Buy', amount: 1, price: it.current }
-    const next = { ...trades, [it.id]: t }
-    setTrades(next)
-    localStorage.setItem('trades', JSON.stringify(next))
+    setDialogItem(it)
   }
 
   // previous table used liveStatus/bookedPct; kept for backward compatibility
@@ -87,6 +86,16 @@ export default function SentimentTable() {
           </tbody>
         </table>
       </div>
+      <OrderDialog
+        open={!!dialogItem}
+        item={dialogItem}
+        onClose={() => setDialogItem(null)}
+        onPlaced={(t) => {
+          const next = { ...trades, [dialogItem.id]: t }
+          setTrades(next)
+          localStorage.setItem('trades', JSON.stringify(next))
+        }}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add backend service and controller to place orders via Kite and fetch funds
- implement `OrderDialog` React component
- integrate order dialog in sentiment table UI

## Testing
- `mvn -q test` *(fails: missing dependencies, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68431a65c3988323b3bc5079fee81009