### PR TITLE
Fix DeleteMapping compile error

### DIFF
--- a/backend/src/main/java/com/backtester/controller/FeedController.java
+++ b/backend/src/main/java/com/backtester/controller/FeedController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import redis.clients.jedis.Jedis;


### PR DESCRIPTION
## Summary
- resolve DeleteMapping import for FeedController

## Testing
- `mvn -q -DskipTests=false package` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684321dec578832380565238e2462976